### PR TITLE
Add remote LDPC worker over UDP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ set(USE_DPDK False CACHE STRING "USE_DPDK defaulting to 'False'")
 set(USE_ARGOS False CACHE STRING "USE_ARGOS defaulting to 'False'")
 set(ENABLE_MAC False CACHE STRING "ENABLE_MAC defaulting to 'False'")
 set(LOG_LEVEL "warn" CACHE STRING "Console logging level (none/error/warn/info/frame/subframe/trace)") 
+set(USE_REMOTE False CACHE STRING "Use remote servers for LDPC (true/false)")
 set(USE_MLX_NIC True CACHE STRING "USE_MLX_NIC defaulting to 'True'")
 set(USE_AVX2_ENCODER False CACHE STRING "Use Agora's AVX2 encoder instead of FlexRAN's AVX512 encoder")
 
@@ -102,7 +103,7 @@ if(${USE_DPDK})
   endif()
 
   if(${USE_MLX_NIC})
-    set(MLX_LIBRARIES -libverbs -lmlx5)
+    set(MLX_LIBRARIES -libverbs -lmlx4 -lmlx5)
   endif()
   set(DPDK_LIBRARIES ${DPDK_LIBRARIES} -Wl,--whole-archive dpdk ${MLX_LIBRARIES} -lnuma -Wl,--no-whole-archive dl)
 
@@ -150,6 +151,11 @@ add_definitions(-DTHREADED_INIT)
 set(BLA_VENDOR Intel10_64lp)
 find_package(BLAS)
 
+if(${USE_REMOTE})
+  message(STATUS "Using remote servers for LDPC")
+  add_definitions(-DUSE_REMOTE)
+endif()
+
 # Console logging level
 if(LOG_LEVEL STREQUAL "none")
   message(STATUS "Logging level = none.")
@@ -182,7 +188,8 @@ include_directories(
 	src/mac/
   src/agora/
   src/agora/txrx/
-  src/client/)
+  src/client/
+  src/remote/)
 
 include_directories(SYSTEM src/third_party)
 
@@ -238,7 +245,7 @@ include_directories(
   ${FLEXRAN_FEC_SDK_DIR}/source/phy/lib_ldpc_encoder_5gnr
   ${FLEXRAN_FEC_SDK_DIR}/source/phy/lib_common
   ${SOURCE_DIR}/src/encoder)
-
+  
 set(FLEXRAN_LDPC_LIBS
   ${FLEXRAN_FEC_LIB_DIR}/source/phy/lib_ldpc_encoder_5gnr/libldpc_encoder_5gnr.a
   ${FLEXRAN_FEC_LIB_DIR}/source/phy/lib_ldpc_decoder_5gnr/libldpc_decoder_5gnr.a
@@ -283,6 +290,25 @@ add_executable(sim
   src/common/dpdk_transport.cpp
   $<TARGET_OBJECTS:common_sources_lib>)
 target_link_libraries(sim ${COMMON_LIBS})
+
+# Add the remote LDPC executable
+if(${USE_REMOTE})
+  add_executable(remote_ldpc
+    src/remote/remote_ldpc.cpp
+    $<TARGET_OBJECTS:common_sources_lib>)
+  target_link_libraries(remote_ldpc ${COMMON_LIBS})
+
+  # NOTE: currently the test_remote_ldpc still uses eRPC, so it doesn't work.
+  # add_executable(test_remote_ldpc 
+  #   test/unit_tests/test_remote_ldpc.cc
+  #   src/remote/remote_ldpc.cpp
+  #   src/agora/stats.cpp
+  #   src/agora/docoding.cpp
+  #   src/agora/phy_stats.cpp
+  #   $<TARGET_OBJECTS:common_sources_lib>)
+  #   target_link_libraries(test_remote_ldpc ${COMMON_LIBS})
+  # add_test(NAME test_remote_ldpc COMMAND test_remote_ldpc)
+endif()
 
 add_executable(chsim
   simulator/chsim_main.cpp

--- a/src/agora/agora.hpp
+++ b/src/agora/agora.hpp
@@ -292,6 +292,9 @@ private:
     moodycamel::ProducerToken* tx_ptoks_ptr[kMaxThreads];
     moodycamel::ProducerToken* worker_ptoks_ptr[kMaxThreads];
     moodycamel::ProducerToken* decode_ptoks_ptr[kMaxThreads];
+
+    /// The thread that handles responses from remote LDPC workers.
+    std::thread remote_ldpc_response_receiver;
 };
 
 #endif

--- a/src/agora/docoding.cpp
+++ b/src/agora/docoding.cpp
@@ -2,11 +2,20 @@
 #include "concurrent_queue_wrapper.hpp"
 #include "encoder.hpp"
 #include "phy_ldpc_decoder_5gnr.h"
+#include "udp_server.h"
+#include "utils_ldpc.hpp"
 #include <malloc.h>
 
 static constexpr bool kPrintEncodedData = false;
 static constexpr bool kPrintLLRData = false;
 static constexpr bool kPrintDecodedData = false;
+
+/// The size of the kernel-level socket receive buffer,
+/// used for receiving responses from the remote LDPC worker.
+static constexpr size_t kRxBufSize = 4 * 1024 * 1024;
+/// The factor used to determine when a remote LDPC worker is considered to be
+/// falling behind and is in an "unhealthy" state.
+static constexpr size_t thresholdPendingRequestsFactor = 10;
 
 DoEncode::DoEncode(Config* in_config, int in_tid, double freq_ghz,
     moodycamel::ConcurrentQueue<Event_data>& in_task_queue,
@@ -99,7 +108,13 @@ DoDecode::DoDecode(Config* in_config, int in_tid, double freq_ghz,
     resp_var_nodes = (int16_t*)memalign(64, 1024 * 1024 * sizeof(int16_t));
 }
 
-DoDecode::~DoDecode() { free(resp_var_nodes); }
+DoDecode::~DoDecode()
+{
+    free(resp_var_nodes);
+    // NOTE: currently, the remote_ldpc_stub_ pointer may be shared with other
+    // DoDecode instances. Therefore, we cannot free it here, but rather
+    // we can only free it safely from within the worker thread.
+}
 
 Event_data DoDecode::launch(size_t tag)
 {
@@ -118,48 +133,9 @@ Event_data DoDecode::launch(size_t tag)
             tid, frame_id, symbol_idx_ul, cur_cb_id, ue_id);
     }
 
-    size_t start_tsc = worker_rdtsc();
-
-    struct bblib_ldpc_decoder_5gnr_request ldpc_decoder_5gnr_request {
-    };
-    struct bblib_ldpc_decoder_5gnr_response ldpc_decoder_5gnr_response {
-    };
-
-    // Decoder setup
-    int16_t numFillerBits = 0;
-    int16_t numChannelLlrs = LDPC_config.cbCodewLen;
-
-    ldpc_decoder_5gnr_request.numChannelLlrs = numChannelLlrs;
-    ldpc_decoder_5gnr_request.numFillerBits = numFillerBits;
-    ldpc_decoder_5gnr_request.maxIterations = LDPC_config.decoderIter;
-    ldpc_decoder_5gnr_request.enableEarlyTermination
-        = LDPC_config.earlyTermination;
-    ldpc_decoder_5gnr_request.Zc = LDPC_config.Zc;
-    ldpc_decoder_5gnr_request.baseGraph = LDPC_config.Bg;
-    ldpc_decoder_5gnr_request.nRows = LDPC_config.nRows;
-
-    int numMsgBits = LDPC_config.cbLen - numFillerBits;
-    ldpc_decoder_5gnr_response.numMsgBits = numMsgBits;
-    ldpc_decoder_5gnr_response.varNodes = resp_var_nodes;
-
+    // `llr_buffer_ptr` is the input buffer into the decoder.
     int8_t* llr_buffer_ptr = demod_buffers_[frame_slot][symbol_idx_ul][ue_id]
         + (cfg->mod_order_bits * (LDPC_config.cbCodewLen * cur_cb_id));
-
-    uint8_t* decoded_buffer_ptr
-        = decoded_buffers_[frame_slot][symbol_idx_ul][ue_id]
-        + (cur_cb_id * roundup<64>(cfg->num_bytes_per_cb));
-
-    ldpc_decoder_5gnr_request.varNodes = llr_buffer_ptr;
-    ldpc_decoder_5gnr_response.compactedMessageBytes = decoded_buffer_ptr;
-
-    size_t start_tsc1 = worker_rdtsc();
-    duration_stat->task_duration[1] += start_tsc1 - start_tsc;
-
-    bblib_ldpc_decoder_5gnr(
-        &ldpc_decoder_5gnr_request, &ldpc_decoder_5gnr_response);
-
-    size_t start_tsc2 = worker_rdtsc();
-    duration_stat->task_duration[2] += start_tsc2 - start_tsc1;
 
     if (kPrintLLRData) {
         printf("LLR data, symbol_offset: %zu\n", symbol_offset);
@@ -169,29 +145,117 @@ Event_data DoDecode::launch(size_t tag)
         printf("\n");
     }
 
-    if (kPrintDecodedData) {
-        printf("Decoded data\n");
-        for (size_t i = 0; i < (LDPC_config.cbLen >> 3); i++) {
-            printf("%u ", *(decoded_buffer_ptr + i));
-        }
-        printf("\n");
-    }
+    // `decoded_buffer_ptr` is the output buffer to which the decoded data
+    // will be written.
+    uint8_t* decoded_buffer_ptr
+        = decoded_buffers_[frame_slot][symbol_idx_ul][ue_id]
+        + (cur_cb_id * roundup<64>(cfg->num_bytes_per_cb));
 
-    if (!kEnableMac && kPrintPhyStats && symbol_idx_ul == cfg->UL_PILOT_SYMS) {
-        phy_stats->update_decoded_bits(
-            ue_id, symbol_offset, cfg->num_bytes_per_cb * 8);
-        phy_stats->increment_decoded_blocks(ue_id, symbol_offset);
-        size_t block_error(0);
-        for (size_t i = 0; i < cfg->num_bytes_per_cb; i++) {
-            uint8_t rx_byte = decoded_buffer_ptr[i];
-            uint8_t tx_byte = (uint8_t)cfg->get_info_bits(
-                cfg->ul_bits, symbol_idx_ul, ue_id, cur_cb_id)[i];
-            phy_stats->update_bit_errors(
-                ue_id, symbol_offset, tx_byte, rx_byte);
-            if (rx_byte != tx_byte)
-                block_error++;
+    size_t start_tsc = worker_rdtsc();
+
+    if (kUseRemote) {
+        auto* decode_context
+            = new DecodeContext(decoded_buffer_ptr, this, tid, tag);
+        size_t data_bytes
+            = ldpc_max_num_encoded_bits(LDPC_config.Bg, LDPC_config.Zc);
+        size_t msg_len = DecodeMsg::size_without_data() + data_bytes;
+        uint16_t dest_port = cfg->remote_ldpc_base_port + tid;
+
+#ifdef USE_DPDK
+        uint16_t src_port = 31850 - 1; /// TODO: FIXME: use proper src port
+        rte_mbuf* tx_mbuf = DpdkTransport::alloc_udp(
+            remote_ldpc_stub_->mbuf_pool, remote_ldpc_stub_->local_mac_addr,
+            remote_ldpc_stub_->remote_mac_addr,
+            remote_ldpc_stub_->local_ip_addr, remote_ldpc_stub_->remote_ip_addr,
+            src_port, dest_port, msg_len);
+        // `msg_buf` points to where our payload starts in the DPDK `tx_mbuf`
+        uint8_t* msg_buf
+            = (rte_pktmbuf_mtod(tx_mbuf, uint8_t*) + kPayloadOffset);
+#else
+        // TODO: pre-allocate a pool of request buffers to avoid this
+        //       temporary allocation on the critical data path.
+        uint8_t* msg_buf = new uint8_t[msg_len];
+#endif // USE_DPDK
+
+        auto* request = reinterpret_cast<DecodeMsg*>(msg_buf);
+        request->context = decode_context;
+        request->msg_id = remote_ldpc_stub_->num_requests_issued;
+        memcpy(request->data, reinterpret_cast<uint8_t*>(llr_buffer_ptr),
+            data_bytes);
+
+        printf("Docoding: Issuing request %zu, context: %p\n",
+            remote_ldpc_stub_->num_requests_issued, request->context);
+        remote_ldpc_stub_->num_requests_issued++;
+
+#ifdef USE_DPDK
+        rt_assert(rte_eth_tx_burst(0, tid, &tx_mbuf, 1) == 1,
+            "rte_eth_tx_burst() failed");
+#else
+        remote_ldpc_stub_->udp_client.send(
+            cfg->remote_ldpc_ip_addr, dest_port, msg_buf, msg_len);
+        delete[] msg_buf; // TODO: remove this once we use request buf pools
+#endif // USE_DPDK
+
+    } else {
+        struct bblib_ldpc_decoder_5gnr_request ldpc_decoder_5gnr_request {
+        };
+        struct bblib_ldpc_decoder_5gnr_response ldpc_decoder_5gnr_response {
+        };
+
+        // Decoder setup
+        int16_t numFillerBits = 0;
+        int16_t numChannelLlrs = LDPC_config.cbCodewLen;
+
+        ldpc_decoder_5gnr_request.numChannelLlrs = numChannelLlrs;
+        ldpc_decoder_5gnr_request.numFillerBits = numFillerBits;
+        ldpc_decoder_5gnr_request.maxIterations = LDPC_config.decoderIter;
+        ldpc_decoder_5gnr_request.enableEarlyTermination
+            = LDPC_config.earlyTermination;
+        ldpc_decoder_5gnr_request.Zc = LDPC_config.Zc;
+        ldpc_decoder_5gnr_request.baseGraph = LDPC_config.Bg;
+        ldpc_decoder_5gnr_request.nRows = LDPC_config.nRows;
+
+        int numMsgBits = LDPC_config.cbLen - numFillerBits;
+        ldpc_decoder_5gnr_response.numMsgBits = numMsgBits;
+        ldpc_decoder_5gnr_response.varNodes = resp_var_nodes;
+
+        ldpc_decoder_5gnr_request.varNodes = llr_buffer_ptr;
+        ldpc_decoder_5gnr_response.compactedMessageBytes = decoded_buffer_ptr;
+
+        size_t start_tsc1 = worker_rdtsc();
+        duration_stat->task_duration[1] += start_tsc1 - start_tsc;
+
+        bblib_ldpc_decoder_5gnr(
+            &ldpc_decoder_5gnr_request, &ldpc_decoder_5gnr_response);
+
+        size_t start_tsc2 = worker_rdtsc();
+        duration_stat->task_duration[2] += start_tsc2 - start_tsc1;
+
+        if (kPrintDecodedData) {
+            printf("Decoded data\n");
+            for (size_t i = 0; i < (LDPC_config.cbLen >> 3); i++) {
+                printf("%u ", *(decoded_buffer_ptr + i));
+            }
+            printf("\n");
         }
-        phy_stats->update_block_errors(ue_id, symbol_offset, block_error);
+
+        if (!kEnableMac && kPrintPhyStats
+            && symbol_idx_ul == cfg->UL_PILOT_SYMS) {
+            phy_stats->update_decoded_bits(
+                ue_id, symbol_offset, cfg->num_bytes_per_cb * 8);
+            phy_stats->increment_decoded_blocks(ue_id, symbol_offset);
+            size_t block_error(0);
+            for (size_t i = 0; i < cfg->num_bytes_per_cb; i++) {
+                uint8_t rx_byte = decoded_buffer_ptr[i];
+                uint8_t tx_byte = (uint8_t)cfg->get_info_bits(
+                    cfg->ul_bits, symbol_idx_ul, ue_id, cur_cb_id)[i];
+                phy_stats->update_bit_errors(
+                    ue_id, symbol_offset, tx_byte, rx_byte);
+                if (rx_byte != tx_byte)
+                    block_error++;
+            }
+            phy_stats->update_block_errors(ue_id, symbol_offset, block_error);
+        }
     }
 
     double duration = worker_rdtsc() - start_tsc;
@@ -202,5 +266,83 @@ Event_data DoDecode::launch(size_t tag)
             cycles_to_us(duration, freq_ghz));
     }
 
-    return Event_data(EventType::kDecode, tag);
+    // When using remote LDPC, we ship the decoding task asynchronously to a
+    // remote server and return immediately
+    if (kUseRemote)
+        return Event_data(EventType::kPendingToRemote, tag);
+    else
+        return Event_data(EventType::kDecode, tag);
+}
+
+/// This function should be run on its own thread to endlessly receive
+/// decode responses from remote LDPC workers and trigger the proper completion
+/// events expected by the rest of Agora.
+/// There should only be one thread instance of this function for the entire
+/// Agora process.
+void decode_response_loop(Config* cfg)
+{
+    UDPServer udp_server(cfg->remote_ldpc_completion_port, kRxBufSize);
+    size_t decoded_bits = ldpc_encoding_input_buf_size(
+        cfg->LDPC_config.Bg, cfg->LDPC_config.Zc);
+    // The number of bytes that we receive at one time from the LDPC worker
+    // is defined by the `DecodeMsg` struct.
+    size_t rx_buf_len = DecodeMsg::size_without_data() + decoded_bits;
+    uint8_t* rx_buf = new uint8_t[rx_buf_len];
+    DecodeMsg* msg = reinterpret_cast<DecodeMsg*>(rx_buf);
+
+    while (cfg->running) {
+        ssize_t bytes_rcvd = udp_server.recv_nonblocking(rx_buf, rx_buf_len);
+        if (bytes_rcvd == 0) {
+            // no data received
+            continue;
+        } else if (bytes_rcvd == -1) {
+            // There was a socket receive error
+            cfg->running = false;
+            break;
+        }
+
+        rt_assert(bytes_rcvd == (ssize_t)rx_buf_len,
+            "Rcvd wrong decode response len");
+        DecodeContext* context = msg->context;
+        DoDecode* computeDecoding = context->doer;
+        rt_assert(
+            context->tid == computeDecoding->tid, "DoDecode tid mismatch");
+
+        // Copy the decoded buffer received from the remote LDPC worker
+        // into the appropriate location in the decode doer's decoded buffer.
+        memcpy(context->output_ptr, msg->data, decoded_bits);
+
+        Event_data resp_event;
+        resp_event.num_tags = 1;
+        resp_event.tags[0] = context->tag;
+        resp_event.event_type = EventType::kDecode;
+
+        try_enqueue_fallback(&computeDecoding->complete_task_queue,
+            computeDecoding->worker_producer_token, resp_event);
+
+        // TODO: here, return msg buffers to the pool
+
+        // `rx_buf` will be reused to receive the next message,
+        // so we only delete the DecodeContext that was allocated
+        // by the DoDecode doer when the request was sent.
+        delete context;
+
+        printf("Docoding: Received response %zu\n", msg->msg_id);
+        computeDecoding->remote_ldpc_stub_->num_responses_received++;
+
+        // Optional: here we can check if we have received far fewer responses
+        // than requests issued, and then issue a health warning.
+        if ((computeDecoding->remote_ldpc_stub_->num_requests_issued
+                - computeDecoding->remote_ldpc_stub_->num_responses_received)
+            > (thresholdPendingRequestsFactor * cfg->UE_ANT_NUM)) {
+            MLPD_WARN("Some remote LDPC requests were lost or got no response. "
+                      "Requests: %zu, Responses: %zu, batch size: %zu\n",
+                computeDecoding->remote_ldpc_stub_->num_requests_issued,
+                computeDecoding->remote_ldpc_stub_->num_responses_received,
+                cfg->UE_ANT_NUM);
+        }
+    }
+
+    printf("Exiting decode_response_loop()\n");
+    delete rx_buf;
 }

--- a/src/agora/docoding.hpp
+++ b/src/agora/docoding.hpp
@@ -11,6 +11,7 @@
 #include "modulation.hpp"
 #include "phy_stats.hpp"
 #include "stats.hpp"
+#include "udp_client.h"
 #include <armadillo>
 #include <iostream>
 #include <stdio.h>
@@ -20,6 +21,89 @@
 #include "encoder.hpp"
 #include "iobuffer.hpp"
 #include "utils_ldpc.hpp"
+
+#ifdef USE_DPDK
+#include "dpdk_transport.hpp"
+#include <arpa/inet.h>
+#include <netinet/ether.h>
+#endif
+
+/// A loop that handles decode responses from all remote LDPC workers.
+void decode_response_loop(Config* cfg);
+
+/// A connection to a remote LDPC worker, including request/receive buffers
+/// and counters.
+/// A single instance of this is shared between the two `DoDecode` instances
+/// in each worker thread.
+class RemoteLdpcStub {
+public:
+    RemoteLdpcStub(Config* cfg, int core_for_dpdk)
+        : num_requests_issued(0)
+        , num_responses_received(0)
+    {
+        _unused(cfg); // used only for DPDK
+        _unused(core_for_dpdk); // used only for DPDK
+
+        // TODO: previously, eRPC req/resp buffers were pre-allocated here.
+        // for (size_t i = 0; i < kRpcMaxMsgBufNum; i++) {
+        //     auto* req_msgbuf = new erpc::MsgBuffer;
+        //     *req_msgbuf = rpc->alloc_msg_buffer_or_die(kRpcMaxMsgSize);
+        //     vec_req_msgbuf.push_back(req_msgbuf);
+        // }
+
+#ifdef USE_DPDK
+        // Init DPDK on only this core
+        DpdkTransport::dpdk_init(core_for_dpdk, 1);
+        mbuf_pool = DpdkTransport::create_mempool();
+
+        uint16_t portid = 0;
+        if (!DpdkTransport::nic_init(portid, mbuf_pool, 1))
+        {
+            rte_exit(EXIT_FAILURE, "Cannot init NIC with port %u\n", portid);
+        }
+
+        // `bs_server_addr` is this machine's local IP address, 
+        // because this code runs on the Agora "server".
+        int ret = inet_pton(AF_INET, cfg->bs_server_addr.c_str(), &local_ip_addr);
+        rt_assert(ret == 1, "Invalid local IP address");
+        ret = inet_pton(
+            AF_INET, cfg->remote_ldpc_ip_addr.c_str(), &remote_ip_addr);
+        rt_assert(ret == 1, "Invalid remote IP address");
+
+        ether_addr* parsed_mac = ether_aton(cfg->remote_ldpc_mac_addr.c_str());
+        rt_assert(parsed_mac != NULL, "Invalid remote LDPC MAC address");
+        memcpy(&remote_mac_addr, parsed_mac, sizeof(ether_addr));
+
+        ret = rte_eth_macaddr_get(portid, &local_mac_addr);
+        rt_assert(ret == 0, "Cannot get MAC address of the port");
+        printf("Number of DPDK cores: %d\n", rte_lcore_count());
+#endif // USE_DPDK
+    }
+
+public:
+    /// Number of preallocated msgbufs to hold pending eRPC requests
+    static const size_t kRpcMaxMsgBufNum = 6400;
+    /// Maximum size of preallocated msgbufs
+    static const size_t kRpcMaxMsgSize = (1 << 15);
+
+    /// The UDP socket used to send decode requests to the remote LDPC worker.
+    UDPClient udp_client;
+    size_t num_requests_issued;
+    size_t num_responses_received;
+
+#ifdef USE_DPDK
+    struct rte_mempool* mbuf_pool;
+    /// The IP address of this local machine.
+    uint32_t local_ip_addr;
+    /// The IP address of the remote LDPC machine.
+    uint32_t remote_ip_addr;
+    /// The MAC address of the NIC we're using on this local machine.
+    rte_ether_addr local_mac_addr;
+    /// The MAC address of the remote LDPC worker to which we send requests.
+    rte_ether_addr remote_mac_addr;
+
+#endif // USE_DPDK
+};
 
 class DoEncode : public Doer {
 public:
@@ -56,12 +140,83 @@ public:
 
     Event_data launch(size_t tag);
 
+    /// Returns the `RemoteLdpcStub` that this doer uses to communicate
+    /// with a remote LDPC worker.
+    /// The returned `RemoteLdpcStub` can be shared with other doers;
+    /// see the `set_initialized_remote_ldpc_stub()` method.
+    RemoteLdpcStub* initialize_remote_ldpc_stub(int core_for_dpdk)
+    {
+        remote_ldpc_stub_ = new RemoteLdpcStub(cfg, core_for_dpdk);
+        return remote_ldpc_stub_;
+    }
+
+    /// Sets this doer's `RemoteLdpcStub` to an already-initialized instance.
+    /// This is useful because a single worker thread creates **two** instances
+    /// of `DoDecode`, and they must share a single `RemoteLdpcStub` context.
+    void set_initialized_remote_ldpc_stub(RemoteLdpcStub* stub)
+    {
+        remote_ldpc_stub_ = stub;
+    }
+
+    /// The loop that runs to receive decode completion responses from
+    /// all remote LDPC workers.
+    /// This is a friend method because it must access private member fields
+    /// within `DoDecode`.
+    friend void decode_response_loop(Config* cfg);
+
 private:
     int16_t* resp_var_nodes;
     PtrCube<kFrameWnd, kMaxSymbols, kMaxUEs, int8_t>& demod_buffers_;
     PtrCube<kFrameWnd, kMaxSymbols, kMaxUEs, uint8_t>& decoded_buffers_;
     PhyStats* phy_stats;
     DurationStat* duration_stat;
+    /// Represents the connection to a remote LDPC worker, which is only used
+    /// when `kUseRemote` is true.
+    RemoteLdpcStub* remote_ldpc_stub_;
 };
 
-#endif
+struct DecodeMsg; // forward declaration
+
+/// A context object used when receiving responses from the remote LDPC worker.
+class DecodeContext {
+public:
+    /// The pointer to which the decoded data should be copied.
+    uint8_t* output_ptr;
+    /// The DoDecode instance that sent the request.
+    DoDecode* doer;
+    /// The worker thread ID that owns (created) the above `doer`.
+    int tid;
+    size_t tag;
+
+    /// TODO: create and use this request buffer pool.
+    std::vector<DecodeMsg*> request_buffer_pool;
+
+    DecodeContext(uint8_t* output_ptr, DoDecode* doer, int tid, size_t tag)
+        : output_ptr(output_ptr)
+        , doer(doer)
+        , tid(tid)
+        , tag(tag)
+    {
+    }
+};
+
+/// The "packet" format of a decode request or response sent between
+/// Agora and a remote LDPC worker.
+struct DecodeMsg {
+    /// The context of this decode request, which is only validly accessible
+    /// from the Agora side where the `DoDecode` instance was created.
+    /// NOTE: THIS IS NOT VALID from within the remote LDPC worker side.
+    DecodeContext* context;
+    /// An optional value used for debugging request/response packet drops.
+    size_t msg_id;
+
+    /// The dynamically-sized data in the message.
+    /// NOTE: THIS MUST BE the last field in this struct.
+    uint8_t data[];
+
+    /// Returns the size of the "header" of this message, i.e.,
+    /// everything before the dynamically-sized data.
+    static size_t size_without_data() { return offsetof(DecodeMsg, data); }
+};
+
+#endif // DOCODING

--- a/src/agora/doer.hpp
+++ b/src/agora/doer.hpp
@@ -26,8 +26,9 @@ public:
                 resp_event.event_type = resp_i.event_type;
             }
 
-            try_enqueue_fallback(
-                &complete_task_queue, worker_producer_token, resp_event);
+            if (resp_event.event_type != EventType::kPendingToRemote)
+                try_enqueue_fallback(
+                    &complete_task_queue, worker_producer_token, resp_event);
             return true;
         }
         return false;

--- a/src/common/Symbols.hpp
+++ b/src/common/Symbols.hpp
@@ -46,10 +46,11 @@ enum class EventType : int {
     kPacketToMac,
     kSNRReport, // Signal new SNR measurement from PHY to MAC
     kRANUpdate, // Signal new RAN config to Agora
-    kRBIndicator // Signal RB schedule to UEs
+    kRBIndicator, // Signal RB schedule to UEs
+    kPendingToRemote // We need to wait for a remote server to respond
 };
 static constexpr size_t kNumEventTypes
-    = static_cast<size_t>(EventType::kPacketToMac) + 1;
+    = static_cast<size_t>(EventType::kPendingToRemote) + 1;
 
 // Types of Agora Doers
 enum class DoerType : size_t {
@@ -218,6 +219,12 @@ static_assert(kTransposeBlockSize % kSCsPerCacheline == 0, "");
 static constexpr bool kUseAVX2Encoder = true;
 #else
 static constexpr bool kUseAVX2Encoder = false;
+#endif
+
+#ifdef USE_REMOTE
+static constexpr bool kUseRemote = true;
+#else
+static constexpr bool kUseRemote = false;
 #endif
 
 // Enable debugging for sender and receiver applications

--- a/src/common/config.hpp
+++ b/src/common/config.hpp
@@ -2,7 +2,7 @@
 #define CONFIG_HEADER
 
 #include <boost/range/algorithm/count.hpp>
-#include <complex.h>
+#include <complex>
 #include <emmintrin.h>
 #include <fstream> // std::ifstream
 #include <immintrin.h>
@@ -301,7 +301,30 @@ public:
     size_t transport_block_size;
     LDPCconfig LDPC_config; // LDPC parameters
 
-    // Number of bytes per code block
+    /* Remote LDPC parameters */
+
+    /// IPv4 address of a remote server available for LDPC
+    std::string remote_ldpc_ip_addr;
+    /// The port on which the main Agora process listens for completion
+    /// events being sent back from remote LDPC servers.
+    int remote_ldpc_completion_port;
+    /// The base port used for setting up remote LDPC listening sockets.
+    /// The ith RemoteLPDC worker listens for requests on port P,
+    /// where `P = remote_ldpc_base_port + i`,
+    /// in which `i` ranges from `[0:remote_ldpc_num_threads)`.
+    int remote_ldpc_base_port;
+    /// Number of LDPC-decoding threads per remote LDPC server
+    size_t remote_ldpc_num_threads;
+    /// Remote LDPC thread `i` runs on core `remote_ldpc_core_offset + i`.
+    size_t remote_ldpc_core_offset;
+#if USE_DPDK
+    /// The MAC address on which the remote LDPC worker receives requests.
+    std::string remote_ldpc_mac_addr;
+    /// The local MAC address through which requests are sent to
+    /// the remote LDPC worker.
+    std::string local_mac_addr;
+#endif // USE_DPDK
+    /// Number of bytes per code block
     size_t num_bytes_per_cb;
 
     bool fft_in_rru; // If true, the RRU does FFT instead of Agora
@@ -323,6 +346,12 @@ public:
 
     // Get the index of this pilot symbol among this frame's pilot symbols
     size_t get_pilot_symbol_idx(size_t frame_id, size_t symbol_id) const;
+
+    // Get the offset of input data for LDPC decoding
+    size_t get_ldpc_input_offset(size_t cb_id) const;
+
+    // Get the offset of output data for LDPC decoding
+    size_t get_ldpc_output_offset(size_t cb_id) const;
 
     bool isPilot(size_t, size_t);
     bool isCalDlPilot(size_t, size_t);

--- a/src/common/dpdk_transport.cpp
+++ b/src/common/dpdk_transport.cpp
@@ -52,6 +52,12 @@ int DpdkTransport::nic_init(
         = RTE_MIN(dev_info.max_rx_pktlen, port_conf.rxmode.max_rx_pkt_len);
     // port_conf.rxmode.offloads |= DEV_RX_OFFLOAD_JUMBO_FRAME;
 
+    // Ensures that Agora gets packets only for the flows we register for
+    struct rte_flow_error error;
+    retval = rte_flow_isolate(port, 1, &error);
+    if (retval != 0)
+        return retval;
+
     retval = rte_eth_dev_configure(port, rxRings, txRings, &port_conf);
     if (retval != 0)
         return retval;

--- a/src/common/logger.h
+++ b/src/common/logger.h
@@ -34,11 +34,11 @@
 #define MLPD_LOG_DEFAULT_STREAM stdout
 
 // Log messages with "FRAME" or higher verbosity get written to
-// trace_file_or_default_stream. This can be stdout for basic debugging, or
+// mlpd_trace_file_or_default_stream. This can be stdout for basic debugging, or
 // a file named "trace_file" for more involved debugging.
 
-//#define trace_file_or_default_stream trace_file
-#define trace_file_or_default_stream MLPD_LOG_DEFAULT_STREAM
+//#define mlpd_trace_file_or_default_stream trace_file
+#define mlpd_trace_file_or_default_stream MLPD_LOG_DEFAULT_STREAM
 
 // If MLPD_LOG_LEVEL is not defined, default to the highest level so that
 // YouCompleteMe does not report compilation errors
@@ -48,7 +48,7 @@
 
 #if MLPD_LOG_LEVEL >= MLPD_LOG_LEVEL_ERROR
 #define MLPD_ERROR(...)                                                        \
-    output_log_header(MLPD_LOG_DEFAULT_STREAM, MLPD_LOG_LEVEL_ERROR);          \
+    mlpd_output_log_header(MLPD_LOG_DEFAULT_STREAM, MLPD_LOG_LEVEL_ERROR);     \
     fprintf(MLPD_LOG_DEFAULT_STREAM, __VA_ARGS__);                             \
     fflush(MLPD_LOG_DEFAULT_STREAM)
 #else
@@ -57,7 +57,7 @@
 
 #if MLPD_LOG_LEVEL >= MLPD_LOG_LEVEL_WARN
 #define MLPD_WARN(...)                                                         \
-    output_log_header(MLPD_LOG_DEFAULT_STREAM, MLPD_LOG_LEVEL_WARN);           \
+    mlpd_output_log_header(MLPD_LOG_DEFAULT_STREAM, MLPD_LOG_LEVEL_WARN);      \
     fprintf(MLPD_LOG_DEFAULT_STREAM, __VA_ARGS__);                             \
     fflush(MLPD_LOG_DEFAULT_STREAM)
 #else
@@ -66,7 +66,7 @@
 
 #if MLPD_LOG_LEVEL >= MLPD_LOG_LEVEL_INFO
 #define MLPD_INFO(...)                                                         \
-    output_log_header(MLPD_LOG_DEFAULT_STREAM, MLPD_LOG_LEVEL_INFO);           \
+    mlpd_output_log_header(MLPD_LOG_DEFAULT_STREAM, MLPD_LOG_LEVEL_INFO);      \
     fprintf(MLPD_LOG_DEFAULT_STREAM, __VA_ARGS__);                             \
     fflush(MLPD_LOG_DEFAULT_STREAM)
 #else
@@ -75,33 +75,36 @@
 
 #if MLPD_LOG_LEVEL >= MLPD_LOG_LEVEL_FRAME
 #define MLPD_FRAME(...)                                                        \
-    output_log_header(trace_file_or_default_stream, MLPD_LOG_LEVEL_FRAME);     \
-    fprintf(trace_file_or_default_stream, __VA_ARGS__);                        \
-    fflush(trace_file_or_default_stream)
+    mlpd_output_log_header(                                                    \
+        mlpd_trace_file_or_default_stream, MLPD_LOG_LEVEL_FRAME);              \
+    fprintf(mlpd_trace_file_or_default_stream, __VA_ARGS__);                   \
+    fflush(mlpd_trace_file_or_default_stream)
 #else
 #define MLPD_FRAME(...) ((void)0)
 #endif
 
 #if MLPD_LOG_LEVEL >= MLPD_LOG_LEVEL_SYMBOL
 #define MLPD_SYMBOL(...)                                                       \
-    output_log_header(trace_file_or_default_stream, MLPD_LOG_LEVEL_SYMBOL);    \
-    fprintf(trace_file_or_default_stream, __VA_ARGS__);                        \
-    fflush(trace_file_or_default_stream)
+    mlpd_output_log_header(                                                    \
+        mlpd_trace_file_or_default_stream, MLPD_LOG_LEVEL_SYMBOL);             \
+    fprintf(mlpd_trace_file_or_default_stream, __VA_ARGS__);                   \
+    fflush(mlpd_trace_file_or_default_stream)
 #else
 #define MLPD_SYMBOL(...) ((void)0)
 #endif
 
 #if MLPD_LOG_LEVEL >= MLPD_LOG_LEVEL_TRACE
 #define MLPD_TRACE(...)                                                        \
-    output_log_header(trace_file_or_default_stream, MLPD_LOG_LEVEL_TRACE);     \
-    fprintf(trace_file_or_default_stream, __VA_ARGS__);                        \
-    fflush(trace_file_or_default_stream)
+    mlpd_output_log_header(                                                    \
+        mlpd_trace_file_or_default_stream, MLPD_LOG_LEVEL_TRACE);              \
+    fprintf(mlpd_trace_file_or_default_stream, __VA_ARGS__);                   \
+    fflush(mlpd_trace_file_or_default_stream)
 #else
 #define MLPD_TRACE(...) ((void)0)
 #endif
 
 /// Return decent-precision time formatted as seconds:microseconds
-static std::string get_formatted_time()
+static std::string mlpd_get_formatted_time()
 {
     struct timespec t;
     clock_gettime(CLOCK_REALTIME, &t);
@@ -114,9 +117,9 @@ static std::string get_formatted_time()
 }
 
 // Output log message header
-static inline void output_log_header(FILE* stream, int level)
+static inline void mlpd_output_log_header(FILE* stream, int level)
 {
-    std::string formatted_time = get_formatted_time();
+    std::string formatted_time = mlpd_get_formatted_time();
 
     const char* type;
     switch (level) {

--- a/src/common/udp_client.h
+++ b/src/common/udp_client.h
@@ -87,8 +87,22 @@ public:
             addrinfo_map[remote_uri] = rem_addrinfo;
         }
 
-        ssize_t ret = sendto(sock_fd, msg, len, 0, rem_addrinfo->ai_addr,
-            rem_addrinfo->ai_addrlen);
+        send_raw(msg, len, rem_addrinfo->ai_addr, rem_addrinfo->ai_addrlen);
+    }
+
+    /**
+     * @brief Send one UDP packet to a remote server without any kind of 
+     * address resolution.
+     *
+     * @param msg Pointer to the message to send
+     * @param len Length in bytes of the message to send
+     * @param rem_addr address and port of the remote server
+     * @param rem_addr_len Length in bytes of the remote address struct
+     */
+    void send_raw(const uint8_t* msg, size_t len, sockaddr* rem_addr,
+        socklen_t rem_addr_len)
+    {
+        ssize_t ret = sendto(sock_fd, msg, len, 0, rem_addr, rem_addr_len);
         if (ret != static_cast<ssize_t>(len)) {
             throw std::runtime_error(
                 "sendto() failed. errno = " + std::string(strerror(errno)));

--- a/src/common/udp_server.h
+++ b/src/common/udp_server.h
@@ -104,6 +104,37 @@ public:
         return ret;
     }
 
+    /**
+     * @brief Try once to receive up to len bytes in buf without blocking. 
+     *        
+     * This is the same as `recv_nonblocking`, but it also returns the
+     * source address from whence the message came.
+     *
+     * @return Return the number of bytes received if non-zero bytes are
+     * received. If no bytes are received, return zero. If there was an error
+     * in receiving, return -1.
+     *
+     * return 0.
+     */
+    ssize_t recvfrom_nonblocking(uint8_t* buf, size_t len,
+        sockaddr* src_addr_out, socklen_t* src_addr_out_len)
+    {
+        ssize_t ret = recvfrom(sock_fd_, static_cast<void*>(buf), len, 0,
+            src_addr_out, src_addr_out_len);
+        if (ret == -1) {
+            if (errno == EAGAIN || ret == EWOULDBLOCK) {
+                // These errors mean that there's no data to receive
+                return 0;
+            } else {
+                fprintf(stderr,
+                    "UDPServer: recv() failed with unexpected error %s\n",
+                    strerror(errno));
+                return ret;
+            }
+        }
+        return ret;
+    }
+
 private:
     uint16_t port_; // The UDP port to listen on
     int sock_fd_ = -1;

--- a/src/remote/remote_ldpc.cpp
+++ b/src/remote/remote_ldpc.cpp
@@ -1,0 +1,149 @@
+#include "remote_ldpc.hpp"
+#include "udp_server.h"
+#include "utils.h"
+#include "utils_ldpc.hpp"
+#include <arpa/inet.h>
+#include <malloc.h>
+#include <string>
+#include <thread>
+#include <vector>
+
+static constexpr size_t kRxBufSize = 4 * 1024 * 1024;
+static bool is_running = true;
+
+RemoteLDPC::RemoteLDPC(Config* cfg, int tid, size_t rx_buf_size)
+    : cfg(cfg)
+    , LDPC_config(cfg->LDPC_config)
+    , tid(tid)
+    , decoded_bits(ldpc_encoding_input_buf_size(LDPC_config.Bg, LDPC_config.Zc))
+    , udp_server(cfg->remote_ldpc_base_port + tid, rx_buf_size)
+{
+    resp_var_nodes = (int16_t*)memalign(64, 1024 * 1024 * sizeof(int16_t));
+    worker_thread = std::thread([=] { worker_loop(tid); });
+}
+
+RemoteLDPC::~RemoteLDPC() { free(resp_var_nodes); }
+
+void RemoteLDPC::decode(int8_t* in_buffer, uint8_t* out_buffer)
+{
+    struct bblib_ldpc_decoder_5gnr_request ldpc_request {
+    };
+    struct bblib_ldpc_decoder_5gnr_response ldpc_response {
+    };
+
+    // Decoder setup
+    int16_t numFillerBits = 0;
+    int16_t numChannelLlrs = LDPC_config.cbCodewLen;
+
+    ldpc_request.numChannelLlrs = numChannelLlrs;
+    ldpc_request.numFillerBits = numFillerBits;
+    ldpc_request.maxIterations = LDPC_config.decoderIter;
+    ldpc_request.enableEarlyTermination = LDPC_config.earlyTermination;
+    ldpc_request.Zc = LDPC_config.Zc;
+    ldpc_request.baseGraph = LDPC_config.Bg;
+    ldpc_request.nRows = LDPC_config.nRows;
+
+    int numMsgBits = LDPC_config.cbLen - numFillerBits;
+    ldpc_response.numMsgBits = numMsgBits;
+    ldpc_response.varNodes = resp_var_nodes;
+
+    ldpc_request.varNodes = in_buffer;
+    ldpc_response.compactedMessageBytes = out_buffer;
+
+    bblib_ldpc_decoder_5gnr(&ldpc_request, &ldpc_response);
+}
+
+/// The main loop that continuously polls for incoming requests,
+/// processes them, and returns a response (if enabled).
+void RemoteLDPC::worker_loop(size_t tid)
+{
+    pin_to_core_with_offset(
+        ThreadType::kWorker, cfg->remote_ldpc_core_offset, tid);
+
+    // Create buffer for receiving a request
+    size_t data_bytes
+        = ldpc_max_num_encoded_bits(LDPC_config.Bg, LDPC_config.Zc);
+    size_t msg_len = DecodeMsg::size_without_data() + data_bytes;
+    uint8_t* rx_buf = new uint8_t[msg_len];
+    DecodeMsg* request = reinterpret_cast<DecodeMsg*>(rx_buf);
+    int8_t* in_buf = reinterpret_cast<int8_t*>(request->data);
+
+    // Create buffer for sending a response
+    size_t decoded_bits = ldpc_encoding_input_buf_size(
+        cfg->LDPC_config.Bg, cfg->LDPC_config.Zc);
+    size_t tx_buf_len = DecodeMsg::size_without_data() + decoded_bits;
+    uint8_t* tx_buf = new uint8_t[tx_buf_len];
+    DecodeMsg* response = reinterpret_cast<DecodeMsg*>(tx_buf);
+    uint8_t* out_buf = reinterpret_cast<uint8_t*>(response->data);
+
+    // Local variables for getting the IP addr of the sender
+    sockaddr from;
+    socklen_t addr_len = sizeof(sockaddr);
+    sockaddr_in* from_ipv4 = reinterpret_cast<sockaddr_in*>(&from);
+    char ipv4_addr[INET_ADDRSTRLEN];
+
+    while (is_running) {
+        ssize_t bytes_rcvd = udp_server.recvfrom_nonblocking(
+            rx_buf, msg_len, &from, &addr_len);
+        if (bytes_rcvd == 0) {
+            // no data received
+            continue;
+        } else if (bytes_rcvd == -1) {
+            // There was a socket receive error
+            is_running = false;
+            break;
+        }
+        rt_assert(
+            bytes_rcvd == (ssize_t)msg_len, "Received wrong size LDPC request");
+        rt_assert(from.sa_family == AF_INET, "Received non-IPv4 UDP packet");
+        inet_ntop(AF_INET, &from_ipv4->sin_addr, ipv4_addr, sizeof(ipv4_addr));
+        std::string response_dest_uri(ipv4_addr);
+
+        printf("RemoteLDPC: Received request %zu from %s, context %p\n",
+            request->msg_id, response_dest_uri.c_str(), request->context);
+
+        decode(in_buf, out_buf);
+        // The `context` ptr is meaningless here in the remote LDPC process,
+        // so we just copy it over such that the asynchronous receiver that 
+        // handles this response from us can handle it with the proper context. 
+        response->context = request->context;
+        response->msg_id = request->msg_id;
+        udp_client.send(response_dest_uri, cfg->remote_ldpc_completion_port,
+            tx_buf, tx_buf_len);
+
+        num_reqs_recvd++;
+    }
+
+    printf("RemoteLDPC worker %zu stopping now.\n", tid);
+    delete[] rx_buf;
+    delete[] tx_buf;
+}
+
+int main(int argc, char** argv)
+{
+    std::string confFile;
+    if (argc == 2) {
+        confFile = std::string(argv[1]);
+    } else {
+        confFile = TOSTRING(PROJECT_DIRECTORY)
+            + std::string("/data/tddconfig-sim-ul.json");
+    }
+    auto* cfg = new Config(confFile.c_str());
+    cfg->genData();
+
+    std::vector<RemoteLDPC*> remote_ldpc_workers;
+    remote_ldpc_workers.reserve(cfg->remote_ldpc_num_threads);
+    for (size_t tid = 0; tid < cfg->remote_ldpc_num_threads; tid++) {
+        remote_ldpc_workers.push_back(new RemoteLDPC(cfg, tid, kRxBufSize));
+    }
+
+    // Wait for all the remote LDPC workers to complete, then free them.
+    for (auto& r : remote_ldpc_workers) {
+        r->join();
+        delete r;
+    }
+
+    // TODO: set signal handler to stop threads upon interruption/kill
+
+    return 0;
+}

--- a/src/remote/remote_ldpc.hpp
+++ b/src/remote/remote_ldpc.hpp
@@ -1,0 +1,75 @@
+/**
+ * This file declares the RemoteLDPC class
+ * and the ldpc request handler function
+ */
+
+#ifndef REMOTE_LDPC
+#define REMOTE_LDPC
+
+#include "config.hpp"
+#include "encoder.hpp"
+#include "phy_ldpc_decoder_5gnr.h"
+#include "udp_client.h"
+#include "udp_server.h"
+#include "docoding.hpp"
+#include <cstdint>
+
+/**
+ * @brief This class is used to process LDPC decoding tasks 
+ * from remote Agora servers. 
+ * 
+ * There is one instance of this class per remote worker thread,
+ * .
+ */
+class RemoteLDPC {
+public:
+    /**
+     * @brief Initialize a RemoteLDPC worker and spawn a thread for it.
+     * 
+     * @param cfg The main Agora-wide configuration info.
+     * @param tid The thread ID on which this LDPC worker runs. 
+     *            This will also determine which UDP port to listen on.
+     * @param rx_buf_size The size of this worker's rx socket buffer, in bytes.
+     * 
+     */
+    RemoteLDPC(Config* cfg, int tid, size_t rx_buf_size);
+    ~RemoteLDPC();
+
+    /// LDPC-decode data from in_buffer and place it in out_buffer
+    void decode(int8_t* in_buffer, uint8_t* out_buffer);
+
+    void worker_loop(size_t tid);
+
+    /// Join this LDPC worker's thread, i.e. wait for it to complete.
+    void join()
+    {
+        if (worker_thread.joinable()) {
+            worker_thread.join();
+        }
+    }
+
+    friend void ldpc_req_handler_test();
+
+private:
+    /// main Agora-wide configuration info.
+    Config* cfg;
+    /// Configurations for RemoteLDPC
+    LDPCconfig LDPC_config;
+    /// The ID of the thread on which this `RemoteLDPC` instance runs on
+    const int tid;
+    /// The worker thread
+    std::thread worker_thread;
+    /// Number of decoded bits for each decoding round
+    const size_t decoded_bits;
+    /// The UDP socket on which we receive LDPC requests
+    UDPServer udp_server;
+    /// The UDP socket on which we send back LDPC responses.
+    UDPClient udp_client;
+
+    // The buffer used to store the code word 16-bit LLR outputs for FlexRAN lib
+    int16_t* resp_var_nodes;
+
+    size_t num_reqs_recvd = 0;
+};
+
+#endif

--- a/test/compute_kernels/test_fft_mkl.c
+++ b/test/compute_kernels/test_fft_mkl.c
@@ -1,7 +1,7 @@
 #include "cpu_attach.hpp"
 #include "mkl_dfti.h"
 #include <cmath>
-#include <complex.h>
+#include <complex>
 #include <immintrin.h>
 #include <iostream>
 #include <stdint.h>

--- a/test/compute_kernels/test_matrix.cpp
+++ b/test/compute_kernels/test_matrix.cpp
@@ -1,7 +1,7 @@
 #include "cpu_attach.hpp"
 // #include "ittnotify.h"
 #include <armadillo>
-#include <complex.h>
+#include <complex>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/compute_kernels/test_mufft.c
+++ b/test/compute_kernels/test_mufft.c
@@ -1,5 +1,5 @@
 #include "mufft/fft.h"
-#include <complex.h>
+#include <complex>
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>

--- a/test/unit_tests/test_remote_ldpc.cc
+++ b/test/unit_tests/test_remote_ldpc.cc
@@ -1,0 +1,282 @@
+#include <gtest/gtest.h>
+// For some reason, gtest include order matters
+#include "concurrentqueue.h"
+#include "config.hpp"
+#include "docoding.hpp"
+#include "gettime.h"
+#include "remote_ldpc.hpp"
+#include "utils.h"
+
+#include <algorithm>
+
+constexpr int kReqType = 2;
+constexpr int kRpcPort = 31850;
+
+static constexpr size_t kNumCodeBlocks = 2;
+static constexpr size_t kBaseGraph = 1;
+static constexpr bool kEnableEarlyTermination = true;
+static constexpr size_t kNumFillerBits = 0;
+static constexpr size_t kMaxDecoderIters = 20;
+static constexpr size_t k5GNRNumPunctured = 2;
+
+RemoteLDPC* remote;
+
+void run_remote(Config* cfg, size_t tid, erpc::Nexus* nexus)
+{
+    pin_to_core_with_offset(
+        ThreadType::kWorker, cfg->remote_ldpc_core_offset, tid);
+
+    remote = new RemoteLDPC(cfg->LDPC_config, tid, nexus);
+    remote->run_erpc_event_loop_forever();
+}
+
+class RemoteLDPCTest : public ::testing::Test {
+public:
+    RemoteLDPCTest()
+    {
+        // Load config file
+        cfg = new Config("data/tddconfig-sim-ul.json");
+        cfg->genData();
+
+        tid = 0;
+        freq_ghz = measure_rdtsc_freq();
+
+        // Prepare event queues for DoDecode object
+        event_queue = moodycamel::ConcurrentQueue<Event_data>(2 * kNumIters);
+        comp_queue = moodycamel::ConcurrentQueue<Event_data>(2 * kNumIters);
+        ptok = new moodycamel::ProducerToken(comp_queue);
+
+        // Prepare input and output buffer for DoDecode object
+        const size_t task_buffer_symbol_num_ul
+            = cfg->ul_data_symbol_num_perframe * TASK_BUFFER_FRAME_NUM;
+        size_t mod_type = cfg->mod_type;
+        demod_soft_buffer.malloc(task_buffer_symbol_num_ul,
+            mod_type * cfg->OFDM_DATA_NUM * cfg->UE_NUM, 64);
+        size_t num_decoded_bytes = (cfg->LDPC_config.cbLen + 7)
+            >> 3 * cfg->LDPC_config.nblocksInSymbol;
+        decoded_buffer.calloc(
+            task_buffer_symbol_num_ul, num_decoded_bytes * cfg->UE_NUM, 64);
+
+        // Prepare stats for DoDecode object
+        stats = new Stats(cfg, kMaxStatBreakdown, freq_ghz);
+        phy_stats = new PhyStats(cfg);
+
+        // Create Dodecode object
+        computeDecoding
+            = new DoDecode(cfg, tid, freq_ghz, event_queue, comp_queue, ptok,
+                demod_soft_buffer, decoded_buffer, phy_stats, stats);
+
+        // Prepare eRPC object for DoDecode object
+        auto uri = cfg->bs_server_addr + ":" + std::to_string(kRpcPort);
+        nexus = new erpc::Nexus(uri, 0, 0);
+        rpc = new erpc::Rpc<erpc::CTransport>(
+            nexus, static_cast<void*>(computeDecoding), tid, basic_sm_handler);
+        rpc->retry_connect_on_invalid_rpc_id = true;
+
+        // Run a different thread to launch a RemoteLDPC object
+        uri = cfg->bs_server_addr + ":" + std::to_string(kRpcPort + 1);
+        ldpc_nexus = new erpc::Nexus(uri, 0, 0);
+        ldpc_nexus->register_req_func(kReqType, ldpc_req_handler);
+        thread = new std::thread(run_remote, cfg, 0, ldpc_nexus);
+
+        // Create session between local eRPC and RemoteLDPC,
+        // and register local eRPC to DoDecode object
+        session = rpc->create_session(uri, 0);
+        rt_assert(session >= 0, "Connect failed!");
+        while (!rpc->is_connected(session)) {
+            rpc->run_event_loop_once();
+        }
+        static_cast<DoDecode*>(computeDecoding)->initialize_erpc(rpc, session);
+    }
+
+    ~RemoteLDPCTest()
+    {
+        remote->stop_loop();
+        thread->join();
+        rpc->destroy_session(session);
+        delete remote;
+        delete computeDecoding;
+        delete rpc;
+        delete nexus;
+        delete ldpc_nexus;
+    }
+
+    // Test whether the local server receives responses from the remote LDPC
+    void test_connectivity()
+    {
+        FastRand fast_rand;
+        size_t start_tsc = rdtsc();
+
+        // For each round, randomly generate frame_ud, symbol_id,
+        // and cb_id, and launch a DoDecode task
+        for (size_t i = 0; i < kNumIters; i++) {
+            uint32_t frame_id = fast_rand.next_u32();
+            size_t symbol_id
+                = (fast_rand.next_u32() % cfg->ul_data_symbol_num_perframe);
+            size_t cb_id = (fast_rand.next_u32()
+                % (cfg->UE_NUM * cfg->LDPC_config.nblocksInSymbol));
+            computeDecoding->launch(
+                gen_tag_t::frm_sym_cb(frame_id, symbol_id, cb_id)._tag);
+            rpc->run_event_loop(10);
+        }
+        double ms = cycles_to_ms(rdtsc() - start_tsc, freq_ghz);
+
+        // Wait for incoming responses
+        rpc->run_event_loop(100);
+
+        // Assert that # tasks launched = # responses
+        ASSERT_EQ(computeDecoding->get_num_responses(), kNumIters);
+    }
+
+    // Test whether the remote LDPC reports the correct decoded results
+    void test_correctness()
+    {
+        // Prepare Data
+        int8_t* input[kNumCodeBlocks];
+        int8_t* parity[kNumCodeBlocks];
+        int8_t* encoded[kNumCodeBlocks];
+        uint8_t* decoded[kNumCodeBlocks];
+
+        std::vector<size_t> zc_vec = { 72 };
+        std::sort(zc_vec.begin(), zc_vec.end());
+
+        for (const size_t& zc : zc_vec) {
+            if (zc > ZC_MAX) {
+                fprintf(stderr,
+                    "Zc value %zu not supported by avx2enc. Skipping.\n", zc);
+                continue;
+            }
+            const size_t num_input_bits = ldpc_num_input_bits(kBaseGraph, zc);
+            const size_t num_parity_bits
+                = ldpc_max_num_parity_bits(kBaseGraph, zc);
+            const size_t num_encoded_bits
+                = ldpc_max_num_encoded_bits(kBaseGraph, zc);
+
+            for (size_t i = 0; i < kNumCodeBlocks; i++) {
+                input[i]
+                    = new int8_t[ldpc_encoding_input_buf_size(kBaseGraph, zc)];
+                parity[i]
+                    = new int8_t[ldpc_encoding_parity_buf_size(kBaseGraph, zc)];
+                encoded[i] = new int8_t[ldpc_encoding_encoded_buf_size(
+                    kBaseGraph, zc)];
+                decoded[i] = new uint8_t[ldpc_encoding_encoded_buf_size(
+                    kBaseGraph, zc)];
+            }
+
+            // Randomly generate input
+            srand(time(NULL));
+            for (size_t n = 0; n < kNumCodeBlocks; n++) {
+                for (size_t i = 0; i < bits_to_bytes(num_input_bits); i++)
+                    input[n][i] = (int8_t)rand();
+            }
+
+            const size_t encoding_start_tsc = rdtsc();
+            for (size_t n = 0; n < kNumCodeBlocks; n++) {
+                ldpc_encode_helper(kBaseGraph, zc,
+                    ldpc_max_num_rows(kBaseGraph), encoded[n], parity[n],
+                    input[n]);
+            }
+
+            // For decoding, generate log-likelihood ratios, one byte per input bit
+            int8_t* llrs[kNumCodeBlocks];
+            for (size_t n = 0; n < kNumCodeBlocks; n++) {
+                llrs[n]
+                    = reinterpret_cast<int8_t*>(memalign(32, num_encoded_bits));
+                for (size_t i = 0; i < num_encoded_bits; i++) {
+                    uint8_t bit_i = (encoded[n][i / 8] >> (i % 8)) & 1;
+                    llrs[n][i] = (bit_i == 1 ? -127 : 127);
+                }
+            }
+
+            // Decoder setup
+            for (size_t n = 0; n < kNumCodeBlocks; n++) {
+                size_t symbol_offset = cfg->get_total_data_symbol_idx_ul(n, 0);
+                size_t input_offset = cfg->get_ldpc_input_offset(0);
+                size_t llr_buffer_offset = input_offset * cfg->mod_type;
+                memcpy(demod_soft_buffer[symbol_offset] + llr_buffer_offset,
+                    llrs[n], num_encoded_bits);
+            }
+
+            // Decoding
+            for (size_t n = 0; n < kNumCodeBlocks; n++) {
+                computeDecoding->launch(gen_tag_t::frm_sym_cb(n, 0, 0)._tag);
+            }
+
+            // Wait for incoming responses
+            rpc->run_event_loop(100);
+
+            for (size_t n = 0; n < kNumCodeBlocks; n++) {
+                size_t symbol_offset = cfg->get_total_data_symbol_idx_ul(n, 0);
+                size_t output_offset = cfg->get_ldpc_output_offset(0);
+                uint8_t* out_buf
+                    = static_cast<uint8_t*>(decoded_buffer[symbol_offset])
+                    + output_offset;
+                memcpy(decoded[n], out_buf,
+                    ldpc_encoding_input_buf_size(kBaseGraph, zc));
+            }
+
+            // Check for errors
+            size_t err_cnt = 0;
+            for (size_t n = 0; n < kNumCodeBlocks; n++) {
+                uint8_t* input_buffer = (uint8_t*)input[n];
+                uint8_t* output_buffer = decoded[n];
+                for (size_t i = 0; i < bits_to_bytes(num_input_bits); i++) {
+                    // printf("input: %i, output: %i\n", input_buffer[i],
+                    // output_buffer[i]);
+                    uint8_t error = input_buffer[i] ^ output_buffer[i];
+                    for (size_t j = 0; j < 8; j++) {
+                        if (i * 8 + j >= num_input_bits) {
+                            continue; // Don't compare beyond end of input bits
+                        }
+                        err_cnt += error & 1;
+                        error >>= 1;
+                    }
+                }
+            }
+
+            printf("Zc = %zu. Bit errors = %zu, BER = %.3f\n", zc, err_cnt,
+                err_cnt * 1.0 / (kNumCodeBlocks * num_input_bits));
+
+            ASSERT_EQ(err_cnt, 0);
+
+            for (size_t i = 0; i < kNumCodeBlocks; i++) {
+                delete[] input[i];
+                delete[] parity[i];
+                delete[] encoded[i];
+                delete[] decoded[i];
+                free(llrs[i]);
+            }
+        }
+    }
+
+private:
+    size_t kNumIters = 5;
+    Config* cfg;
+    moodycamel::ConcurrentQueue<Event_data> event_queue;
+    moodycamel::ConcurrentQueue<Event_data> comp_queue;
+    moodycamel::ProducerToken* ptok;
+    Table<int8_t> demod_soft_buffer;
+    Table<uint8_t> decoded_buffer;
+    Stats* stats;
+    PhyStats* phy_stats;
+    DoDecode* computeDecoding;
+    erpc::Nexus* nexus;
+    erpc::Nexus* ldpc_nexus;
+    erpc::Rpc<erpc::CTransport>* rpc;
+    std::thread* thread;
+    int session;
+    int tid;
+    double freq_ghz;
+};
+
+TEST_F(RemoteLDPCTest, create) {}
+
+TEST_F(RemoteLDPCTest, test_connectivity) { test_connectivity(); }
+
+TEST_F(RemoteLDPCTest, test_correctness) { test_correctness(); }
+
+int main(int argc, char** argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Remote LDPC worker(s) can be spawned to perform LDPC decoding tasks in separate processes. Communication with the main Agora process occurs over UDP; DPDK support is unfinished. 

Provide the `-DUSE_REMOTE=on` option to `cmake` to enable this, and then the remote LDPC worker should be run alongside the main Agora process, e.g.,:
```
./build/remote_ldpc data/tddconfig-sim-ul.json
./build/agora data/tddconfig-sim-ul.json
# run sender here
```
See the `if (kUseRemote)` conditional within `config.cpp` (and the corresponding field definitions within `config.hpp` for an explanation of the configuration values that can be provided to the remote LDPC worker and Agora. 

The `test_remote_ldpc` test has not yet been adapted to the new UDP-based scheme. 