### PR TITLE
Fix major slowdown caused by PtrGrid and PtrCube by returning references instead of array copies

### DIFF
--- a/src/agora/dodemul.hpp
+++ b/src/agora/dodemul.hpp
@@ -17,7 +17,9 @@
 #include <string.h>
 #include <vector>
 
-#define USE_MKL_JIT 0 // JIT for cgemm is only available after MKL 2019 update 3
+// Just-in-time optimization for MKL cgemm is available only after MKL 2019
+// update 3. Disable this on systems with an older MKL version.
+#define USE_MKL_JIT 1
 
 using namespace arma;
 class DoDemul : public Doer {

--- a/src/agora/dodemul.hpp
+++ b/src/agora/dodemul.hpp
@@ -19,7 +19,11 @@
 
 // Just-in-time optimization for MKL cgemm is available only after MKL 2019
 // update 3. Disable this on systems with an older MKL version.
+#if __INTEL_MKL__ >= 2020 || (__INTEL_MKL__ == 2019 && __INTEL_MKL_UPDATE__ > 3)
 #define USE_MKL_JIT 1
+#else
+#define USE_MKL_JIT 0
+#endif
 
 using namespace arma;
 class DoDemul : public Doer {

--- a/src/agora/stats.hpp
+++ b/src/agora/stats.hpp
@@ -15,7 +15,8 @@ static constexpr size_t kMaxStatBreakdown = 4;
 struct DurationStat {
     size_t task_duration[kMaxStatBreakdown]; // Unit = TSC cycles
     size_t task_count;
-    DurationStat() { memset(this, 0, sizeof(DurationStat)); }
+    DurationStat() { reset(); }
+    void reset() { memset(this, 0, sizeof(DurationStat)); }
 };
 
 // Temporary summary statistics assembled from per-thread runtime stats

--- a/src/common/memory_manage.h
+++ b/src/common/memory_manage.h
@@ -147,7 +147,7 @@ public:
         }
     }
 
-    std::array<T*, COLS> operator[](size_t row_idx) { return mat[row_idx]; }
+    std::array<T*, COLS>& operator[](size_t row_idx) { return mat[row_idx]; }
 
     // Delete copy constructor and copy assignment
     PtrGrid(PtrGrid const&) = delete;
@@ -218,7 +218,7 @@ public:
         }
     }
 
-    std::array<std::array<T*, DIM3>, DIM2> operator[](size_t row_idx)
+    std::array<std::array<T*, DIM3>, DIM2>& operator[](size_t row_idx)
     {
         return cube[row_idx];
     }

--- a/test/unit_tests/test_ptr_grid.cc
+++ b/test/unit_tests/test_ptr_grid.cc
@@ -1,15 +1,17 @@
-#include "memory_manage.h"
 #include <gtest/gtest.h>
+#define private public
+#include "memory_manage.h"
 
-static constexpr size_t kRows = 40;
-static constexpr size_t kCols = 1200;
+static constexpr size_t kRows = 4;
+static constexpr size_t kCols = 12;
 static constexpr size_t kCol2s = 64;
-const size_t n_entries = 64 * 32;
+const size_t n_entries = 64;
 
 TEST(TestPtrGrid, Basic)
 {
     PtrGrid<kRows, kCols, float> ptr_grid(n_entries);
 
+    // Test basic accesses and zero-initialization
     float sum = 0;
     for (size_t i = 0; i < kRows; i++) {
         for (size_t j = 0; j < kCols; j++) {
@@ -18,12 +20,17 @@ TEST(TestPtrGrid, Basic)
     }
 
     ASSERT_EQ(sum, 0.0);
+
+    // Test that [] operator returns a reference, not a copy
+    ptr_grid[0][0] = nullptr;
+    ASSERT_EQ(ptr_grid.mat[0][0], nullptr);
 }
 
 TEST(TestPtrCube, Basic)
 {
     PtrCube<kRows, kCols, kCol2s, float> ptr_cube(n_entries);
 
+    // Test basic accesses and zero-initialization
     float sum = 0;
     for (size_t i = 0; i < kRows; i++) {
         for (size_t j = 0; j < kCols; j++) {
@@ -34,6 +41,10 @@ TEST(TestPtrCube, Basic)
     }
 
     ASSERT_EQ(sum, 0.0);
+
+    // Test that [] operator returns a reference, not a copy
+    ptr_cube[0][0][0] = nullptr;
+    ASSERT_EQ(ptr_cube.cube[0][0][0], nullptr);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
Also:
- Enable JIT for MKL by default
- Augment matrix multiplication benchmark to allow fetching matrices from DRAM