### PR TITLE
Remove special queue for inter-frame pipeline parallelism

### DIFF
--- a/src/agora/agora.cpp
+++ b/src/agora/agora.cpp
@@ -1097,7 +1097,6 @@ void Agora::initialize_queues()
     message_queue_ = mt_queue_t(512 * data_symbol_num_perframe);
     for (auto& c : complete_task_queue_)
         c = mt_queue_t(256 * data_symbol_num_perframe);
-    // complete_decode_task_queue_ = mt_queue_t(2048);
 
     // Create concurrent queues for each Doer
     for (auto& vec : sched_info_arr) {
@@ -1117,8 +1116,6 @@ void Agora::initialize_queues()
         for (size_t j = 0; j < 2; j++)
             worker_ptoks_ptr[i][j]
                 = new moodycamel::ProducerToken(complete_task_queue_[j]);
-        // decode_ptoks_ptr[i]
-        //     = new moodycamel::ProducerToken(complete_decode_task_queue_);
     }
 }
 

--- a/src/agora/agora.hpp
+++ b/src/agora/agora.hpp
@@ -107,15 +107,17 @@ public:
 
 private:
     /// Fetch the concurrent queue for this event type
-    moodycamel::ConcurrentQueue<Event_data>* get_conq(EventType event_type)
+    moodycamel::ConcurrentQueue<Event_data>* get_conq(
+        EventType event_type, size_t qid)
     {
-        return &sched_info_arr[static_cast<size_t>(event_type)].concurrent_q;
+        return &sched_info_arr[qid][static_cast<size_t>(event_type)]
+                    .concurrent_q;
     }
 
     /// Fetch the producer token for this event type
-    moodycamel::ProducerToken* get_ptok(EventType event_type)
+    moodycamel::ProducerToken* get_ptok(EventType event_type, size_t qid)
     {
-        return sched_info_arr[static_cast<size_t>(event_type)].ptok;
+        return sched_info_arr[qid][static_cast<size_t>(event_type)].ptok;
     }
 
     /// Return a string containing the sizes of the FFT queues
@@ -267,7 +269,7 @@ private:
         moodycamel::ConcurrentQueue<Event_data> concurrent_q;
         moodycamel::ProducerToken* ptok;
     };
-    sched_info_t sched_info_arr[kNumEventTypes];
+    sched_info_t sched_info_arr[2][kNumEventTypes];
 
     // Master thread's message queue for receiving packets
     moodycamel::ConcurrentQueue<Event_data> message_queue_;
@@ -279,15 +281,15 @@ private:
     moodycamel::ConcurrentQueue<Event_data> mac_response_queue_;
 
     // Master thread's message queue for event completion from Doers;
-    moodycamel::ConcurrentQueue<Event_data> complete_task_queue_;
+    moodycamel::ConcurrentQueue<Event_data> complete_task_queue_[2];
 
-    // Master thread's message queue for event completion from DoDecode;
-    moodycamel::ConcurrentQueue<Event_data> complete_decode_task_queue_;
+    // // Master thread's message queue for event completion from DoDecode;
+    // moodycamel::ConcurrentQueue<Event_data> complete_decode_task_queue_;
 
     moodycamel::ProducerToken* rx_ptoks_ptr[kMaxThreads];
     moodycamel::ProducerToken* tx_ptoks_ptr[kMaxThreads];
-    moodycamel::ProducerToken* worker_ptoks_ptr[kMaxThreads];
-    moodycamel::ProducerToken* decode_ptoks_ptr[kMaxThreads];
+    moodycamel::ProducerToken* worker_ptoks_ptr[kMaxThreads][2];
+    // moodycamel::ProducerToken* decode_ptoks_ptr[kMaxThreads];
 };
 
 #endif

--- a/src/agora/agora.hpp
+++ b/src/agora/agora.hpp
@@ -83,9 +83,6 @@ public:
     void send_snr_report(
         EventType event_type, size_t frame_id, size_t symbol_id);
 
-    void move_events_between_queues(
-        EventType event_type1, EventType event_type2);
-
     void initialize_queues();
     void initialize_uplink_buffers();
     void initialize_downlink_buffers();
@@ -216,6 +213,15 @@ private:
     RxCounters rx_counters_;
     size_t zf_last_frame = SIZE_MAX;
     size_t rc_last_frame = SIZE_MAX;
+
+    // Agora schedules and processes a frame in FIFO order
+    // cur_proc_frame_id is the frame that is currently being processed.
+    // cur_sche_frame_id is the frame that is currently being scheduled.
+    // A frame's schduling finishes before processing ends, so the two
+    // variables are possible to have different values.
+    size_t cur_proc_frame_id = 0;
+    size_t cur_sche_frame_id = 0;
+
     // The frame index for a symbol whose FFT is done
     std::vector<size_t> fft_cur_frame_for_symbol;
     // The frame index for a symbol whose encode is done
@@ -282,14 +288,10 @@ private:
 
     // Master thread's message queue for event completion from Doers;
     moodycamel::ConcurrentQueue<Event_data> complete_task_queue_[2];
-
-    // // Master thread's message queue for event completion from DoDecode;
-    // moodycamel::ConcurrentQueue<Event_data> complete_decode_task_queue_;
+    moodycamel::ProducerToken* worker_ptoks_ptr[kMaxThreads][2];
 
     moodycamel::ProducerToken* rx_ptoks_ptr[kMaxThreads];
     moodycamel::ProducerToken* tx_ptoks_ptr[kMaxThreads];
-    moodycamel::ProducerToken* worker_ptoks_ptr[kMaxThreads][2];
-    // moodycamel::ProducerToken* decode_ptoks_ptr[kMaxThreads];
 };
 
 #endif

--- a/src/agora/docoding.cpp
+++ b/src/agora/docoding.cpp
@@ -9,13 +9,9 @@ static constexpr bool kPrintLLRData = false;
 static constexpr bool kPrintDecodedData = false;
 
 DoEncode::DoEncode(Config* in_config, int in_tid, double freq_ghz,
-    moodycamel::ConcurrentQueue<Event_data>& in_task_queue,
-    moodycamel::ConcurrentQueue<Event_data>& complete_task_queue,
-    moodycamel::ProducerToken* worker_producer_token,
     Table<int8_t>& in_raw_data_buffer, Table<int8_t>& in_encoded_buffer,
     Stats* in_stats_manager)
-    : Doer(in_config, in_tid, freq_ghz, in_task_queue, complete_task_queue,
-          worker_producer_token)
+    : Doer(in_config, in_tid, freq_ghz)
     , raw_data_buffer_(in_raw_data_buffer)
     , encoded_buffer_(in_encoded_buffer)
 {
@@ -83,14 +79,10 @@ Event_data DoEncode::launch(size_t tag)
 }
 
 DoDecode::DoDecode(Config* in_config, int in_tid, double freq_ghz,
-    moodycamel::ConcurrentQueue<Event_data>& in_task_queue,
-    moodycamel::ConcurrentQueue<Event_data>& complete_task_queue,
-    moodycamel::ProducerToken* worker_producer_token,
     PtrCube<kFrameWnd, kMaxSymbols, kMaxUEs, int8_t>& demod_buffers,
     PtrCube<kFrameWnd, kMaxSymbols, kMaxUEs, uint8_t>& decoded_buffers,
     PhyStats* in_phy_stats, Stats* in_stats_manager)
-    : Doer(in_config, in_tid, freq_ghz, in_task_queue, complete_task_queue,
-          worker_producer_token)
+    : Doer(in_config, in_tid, freq_ghz)
     , demod_buffers_(demod_buffers)
     , decoded_buffers_(decoded_buffers)
     , phy_stats(in_phy_stats)

--- a/src/agora/docoding.hpp
+++ b/src/agora/docoding.hpp
@@ -24,9 +24,6 @@
 class DoEncode : public Doer {
 public:
     DoEncode(Config* in_config, int in_tid, double freq_ghz,
-        moodycamel::ConcurrentQueue<Event_data>& in_task_queue,
-        moodycamel::ConcurrentQueue<Event_data>& complete_task_queue,
-        moodycamel::ProducerToken* worker_producer_token,
         Table<int8_t>& in_raw_data_buffer, Table<int8_t>& in_encoded_buffer,
         Stats* in_stats_manager);
     ~DoEncode();
@@ -46,9 +43,6 @@ private:
 class DoDecode : public Doer {
 public:
     DoDecode(Config* in_config, int in_tid, double freq_ghz,
-        moodycamel::ConcurrentQueue<Event_data>& in_task_queue,
-        moodycamel::ConcurrentQueue<Event_data>& complete_task_queue,
-        moodycamel::ProducerToken* worker_producer_token,
         PtrCube<kFrameWnd, kMaxSymbols, kMaxUEs, int8_t>& demod_buffers,
         PtrCube<kFrameWnd, kMaxSymbols, kMaxUEs, uint8_t>& decoded_buffers,
         PhyStats* in_phy_stats, Stats* in_stats_manager);

--- a/src/agora/dodemul.cpp
+++ b/src/agora/dodemul.cpp
@@ -5,17 +5,13 @@
 static constexpr bool kUseSIMDGather = true;
 
 DoDemul::DoDemul(Config* config, int tid, double freq_ghz,
-    moodycamel::ConcurrentQueue<Event_data>& task_queue,
-    moodycamel::ConcurrentQueue<Event_data>& complete_task_queue,
-    moodycamel::ProducerToken* worker_producer_token,
     Table<complex_float>& data_buffer,
     PtrGrid<kFrameWnd, kMaxDataSCs, complex_float>& ul_zf_matrices,
     Table<complex_float>& ue_spec_pilot_buffer,
     Table<complex_float>& equal_buffer,
     PtrCube<kFrameWnd, kMaxSymbols, kMaxUEs, int8_t>& demod_buffers,
     PhyStats* in_phy_stats, Stats* stats_manager)
-    : Doer(config, tid, freq_ghz, task_queue, complete_task_queue,
-          worker_producer_token)
+    : Doer(config, tid, freq_ghz)
     , data_buffer_(data_buffer)
     , ul_zf_matrices_(ul_zf_matrices)
     , ue_spec_pilot_buffer_(ue_spec_pilot_buffer)

--- a/src/agora/dodemul.hpp
+++ b/src/agora/dodemul.hpp
@@ -20,9 +20,6 @@ using namespace arma;
 class DoDemul : public Doer {
 public:
     DoDemul(Config* config, int tid, double freq_ghz,
-        moodycamel::ConcurrentQueue<Event_data>& task_queue,
-        moodycamel::ConcurrentQueue<Event_data>& complete_task_queue,
-        moodycamel::ProducerToken* worker_producer_token,
         Table<complex_float>& data_buffer,
         PtrGrid<kFrameWnd, kMaxDataSCs, complex_float>& ul_zf_matrices,
         Table<complex_float>& ue_spec_pilot_buffer,

--- a/src/agora/doer.hpp
+++ b/src/agora/doer.hpp
@@ -10,10 +10,12 @@ class Config;
 
 class Doer {
 public:
-    virtual bool try_launch(void)
+    virtual bool try_launch(moodycamel::ConcurrentQueue<Event_data>& task_queue,
+        moodycamel::ConcurrentQueue<Event_data>& complete_task_queue,
+        moodycamel::ProducerToken* worker_ptok)
     {
         Event_data req_event;
-        if (task_queue_.try_dequeue(req_event)) {
+        if (task_queue.try_dequeue(req_event)) {
             // We will enqueue one response event containing results for all
             // request tags in the request event
             Event_data resp_event;
@@ -26,8 +28,7 @@ public:
                 resp_event.event_type = resp_i.event_type;
             }
 
-            try_enqueue_fallback(
-                &complete_task_queue, worker_producer_token, resp_event);
+            try_enqueue_fallback(&complete_task_queue, worker_ptok, resp_event);
             return true;
         }
         return false;
@@ -53,16 +54,10 @@ public:
     }
 
 protected:
-    Doer(Config* in_config, int in_tid, double freq_ghz,
-        moodycamel::ConcurrentQueue<Event_data>& in_task_queue,
-        moodycamel::ConcurrentQueue<Event_data>& complete_task_queue,
-        moodycamel::ProducerToken* worker_producer_token)
+    Doer(Config* in_config, int in_tid, double freq_ghz)
         : cfg(in_config)
         , tid(in_tid)
         , freq_ghz(freq_ghz)
-        , task_queue_(in_task_queue)
-        , complete_task_queue(complete_task_queue)
-        , worker_producer_token(worker_producer_token)
     {
     }
 
@@ -71,8 +66,5 @@ protected:
     Config* cfg;
     int tid; // Thread ID of this Doer
     double freq_ghz; // RDTSC frequency in GHz
-    moodycamel::ConcurrentQueue<Event_data>& task_queue_;
-    moodycamel::ConcurrentQueue<Event_data>& complete_task_queue;
-    moodycamel::ProducerToken* worker_producer_token;
 };
 #endif /* DOER */

--- a/src/agora/dofft.cpp
+++ b/src/agora/dofft.cpp
@@ -12,16 +12,12 @@ static constexpr bool kUseOutOfPlaceIFFT = false;
 static constexpr bool kMemcpyBeforeIFFT = true;
 
 DoFFT::DoFFT(Config* config, int tid, double freq_ghz,
-    moodycamel::ConcurrentQueue<Event_data>& task_queue,
-    moodycamel::ConcurrentQueue<Event_data>& complete_task_queue,
-    moodycamel::ProducerToken* worker_producer_token,
     Table<char>& socket_buffer, Table<int>& socket_buffer_status,
     Table<complex_float>& data_buffer,
     PtrGrid<kFrameWnd, kMaxUEs, complex_float>& csi_buffers,
     Table<complex_float>& calib_buffer, PhyStats* in_phy_stats,
     Stats* stats_manager)
-    : Doer(config, tid, freq_ghz, task_queue, complete_task_queue,
-          worker_producer_token)
+    : Doer(config, tid, freq_ghz)
     , socket_buffer_(socket_buffer)
     , socket_buffer_status_(socket_buffer_status)
     , data_buffer_(data_buffer)
@@ -237,13 +233,9 @@ void DoFFT::partial_transpose(
 }
 
 DoIFFT::DoIFFT(Config* in_config, int in_tid, double freq_ghz,
-    moodycamel::ConcurrentQueue<Event_data>& in_task_queue,
-    moodycamel::ConcurrentQueue<Event_data>& complete_task_queue,
-    moodycamel::ProducerToken* worker_producer_token,
     Table<complex_float>& in_dl_ifft_buffer, char* in_dl_socket_buffer,
     Stats* in_stats_manager)
-    : Doer(in_config, in_tid, freq_ghz, in_task_queue, complete_task_queue,
-          worker_producer_token)
+    : Doer(in_config, in_tid, freq_ghz)
     , dl_ifft_buffer_(in_dl_ifft_buffer)
     , dl_socket_buffer_(in_dl_socket_buffer)
 {

--- a/src/agora/dofft.hpp
+++ b/src/agora/dofft.hpp
@@ -18,12 +18,8 @@
 
 class DoFFT : public Doer {
 public:
-    DoFFT(Config* config, int tid, double freq_ghz,
-        moodycamel::ConcurrentQueue<Event_data>& task_queue,
-        moodycamel::ConcurrentQueue<Event_data>& complete_task_queue,
-        moodycamel::ProducerToken* worker_producer_token,
-        Table<char>& socket_buffer, Table<int>& socket_buffer_status,
-        Table<complex_float>& data_buffer,
+    DoFFT(Config* config, int tid, double freq_ghz, Table<char>& socket_buffer,
+        Table<int>& socket_buffer_status, Table<complex_float>& data_buffer,
         PtrGrid<kFrameWnd, kMaxUEs, complex_float>& csi_buffers,
         Table<complex_float>& calib_buffer, PhyStats* in_phy_stats,
         Stats* stats_manager);
@@ -114,9 +110,6 @@ private:
 class DoIFFT : public Doer {
 public:
     DoIFFT(Config* in_config, int in_tid, double freq_ghz,
-        moodycamel::ConcurrentQueue<Event_data>& in_task_queue,
-        moodycamel::ConcurrentQueue<Event_data>& complete_task_queue,
-        moodycamel::ProducerToken* worker_producer_token,
         Table<complex_float>& in_dl_ifft_buffer, char* in_dl_socket_buffer,
         Stats* in_stats_manager);
     ~DoIFFT();

--- a/src/agora/doprecode.cpp
+++ b/src/agora/doprecode.cpp
@@ -5,15 +5,11 @@ using namespace arma;
 static constexpr bool kUseSpatialLocality = true;
 
 DoPrecode::DoPrecode(Config* in_config, int in_tid, double freq_ghz,
-    moodycamel::ConcurrentQueue<Event_data>& in_task_queue,
-    moodycamel::ConcurrentQueue<Event_data>& complete_task_queue,
-    moodycamel::ProducerToken* worker_producer_token,
     PtrGrid<kFrameWnd, kMaxDataSCs, complex_float>& dl_zf_matrices,
     Table<complex_float>& in_dl_ifft_buffer,
     Table<int8_t>& dl_encoded_or_raw_data /* Encoded if LDPC is enabled */,
     Stats* in_stats_manager)
-    : Doer(in_config, in_tid, freq_ghz, in_task_queue, complete_task_queue,
-          worker_producer_token)
+    : Doer(in_config, in_tid, freq_ghz)
     , dl_zf_matrices_(dl_zf_matrices)
     , dl_ifft_buffer_(in_dl_ifft_buffer)
     , dl_raw_data(dl_encoded_or_raw_data)

--- a/src/agora/doprecode.hpp
+++ b/src/agora/doprecode.hpp
@@ -19,9 +19,6 @@
 class DoPrecode : public Doer {
 public:
     DoPrecode(Config* in_config, int in_tid, double freq_ghz,
-        moodycamel::ConcurrentQueue<Event_data>& in_task_queue,
-        moodycamel::ConcurrentQueue<Event_data>& complete_task_queue,
-        moodycamel::ProducerToken* worker_producer_token,
         PtrGrid<kFrameWnd, kMaxDataSCs, complex_float>& dl_zf_matrices_,
         Table<complex_float>& in_dl_ifft_buffer,
         Table<int8_t>& dl_encoded_buffer, Stats* in_stats_manager);

--- a/src/agora/dozf.cpp
+++ b/src/agora/dozf.cpp
@@ -9,16 +9,12 @@ static constexpr bool kUseSIMDGather = true;
 static constexpr size_t kUseInverseForZF = true;
 
 DoZF::DoZF(Config* config, int tid, double freq_ghz,
-    moodycamel::ConcurrentQueue<Event_data>& task_queue,
-    moodycamel::ConcurrentQueue<Event_data>& complete_task_queue,
-    moodycamel::ProducerToken* worker_producer_token,
     PtrGrid<kFrameWnd, kMaxUEs, complex_float>& csi_buffers,
     Table<complex_float>& calib_buffer,
     PtrGrid<kFrameWnd, kMaxDataSCs, complex_float>& ul_zf_matrices,
     PtrGrid<kFrameWnd, kMaxDataSCs, complex_float>& dl_zf_matrices,
     Stats* stats_manager)
-    : Doer(config, tid, freq_ghz, task_queue, complete_task_queue,
-          worker_producer_token)
+    : Doer(config, tid, freq_ghz)
     , csi_buffers_(csi_buffers)
     , calib_buffer_(calib_buffer)
     , ul_zf_matrices_(ul_zf_matrices)

--- a/src/agora/dozf.hpp
+++ b/src/agora/dozf.hpp
@@ -17,9 +17,6 @@
 class DoZF : public Doer {
 public:
     DoZF(Config* in_config, int tid, double freq_ghz,
-        moodycamel::ConcurrentQueue<Event_data>& task_queue,
-        moodycamel::ConcurrentQueue<Event_data>& complete_task_queue,
-        moodycamel::ProducerToken* worker_producer_token,
         PtrGrid<kFrameWnd, kMaxUEs, complex_float>& csi_buffers,
         Table<complex_float>& calib_buffer,
         PtrGrid<kFrameWnd, kMaxDataSCs, complex_float>& ul_zf_matrices_,

--- a/src/common/Symbols.hpp
+++ b/src/common/Symbols.hpp
@@ -44,7 +44,6 @@ enum class EventType : int {
     kPacketTX,
     kPacketPilotTX,
     kDecode,
-    kDecodeLast,
     kEncode,
     kModul,
     kPacketFromMac,

--- a/src/common/Symbols.hpp
+++ b/src/common/Symbols.hpp
@@ -46,7 +46,6 @@ enum class EventType : int {
     kDecode,
     kDecodeLast,
     kEncode,
-    kRC,
     kModul,
     kPacketFromMac,
     kPacketToMac,

--- a/test/unit_tests/test_demul_threaded.cc
+++ b/test/unit_tests/test_demul_threaded.cc
@@ -72,9 +72,9 @@ void MasterToWorkerDynamic_worker(Config* cfg, size_t worker_id,
         // Wait
     }
 
-    auto computeDemul = new DoDemul(cfg, worker_id, freq_ghz, event_queue,
-        complete_task_queue, ptok, data_buffer, ul_zf_matrices,
-        ue_spec_pilot_buffer, equal_buffer, demod_buffers_, phy_stats, stats);
+    auto computeDemul = new DoDemul(cfg, worker_id, freq_ghz, data_buffer,
+        ul_zf_matrices, ue_spec_pilot_buffer, equal_buffer, demod_buffers_,
+        phy_stats, stats);
 
     size_t start_tsc = rdtsc();
     size_t num_tasks = 0;

--- a/test/unit_tests/test_zf.cc
+++ b/test/unit_tests/test_zf.cc
@@ -16,10 +16,6 @@ TEST(TestZF, Perf)
     int tid = 0;
     double freq_ghz = measure_rdtsc_freq();
 
-    auto event_queue = moodycamel::ConcurrentQueue<Event_data>(2 * kNumIters);
-    auto comp_queue = moodycamel::ConcurrentQueue<Event_data>(2 * kNumIters);
-    auto ptok = new moodycamel::ProducerToken(comp_queue);
-
     PtrGrid<kFrameWnd, kMaxUEs, complex_float> csi_buffers;
     csi_buffers.rand_alloc_cx_float(cfg->BS_ANT_NUM * cfg->OFDM_DATA_NUM);
 
@@ -34,8 +30,8 @@ TEST(TestZF, Perf)
 
     auto stats = new Stats(cfg, kMaxStatBreakdown, freq_ghz);
 
-    auto computeZF = new DoZF(cfg, tid, freq_ghz, event_queue, comp_queue, ptok,
-        csi_buffers, calib_buffer, ul_zf_matrices, dl_zf_matrices, stats);
+    auto computeZF = new DoZF(cfg, tid, freq_ghz, csi_buffers, calib_buffer,
+        ul_zf_matrices, dl_zf_matrices, stats);
 
     FastRand fast_rand;
     size_t start_tsc = rdtsc();

--- a/test/unit_tests/test_zf_threaded.cc
+++ b/test/unit_tests/test_zf_threaded.cc
@@ -67,9 +67,8 @@ void MasterToWorkerDynamic_worker(Config* cfg, size_t worker_id,
         // Wait
     }
 
-    auto computeZF = new DoZF(cfg, worker_id, freq_ghz, event_queue,
-        complete_task_queue, ptok, csi_buffers, calib_buffer, ul_zf_matrices,
-        dl_zf_matrices, stats);
+    auto computeZF = new DoZF(cfg, worker_id, freq_ghz, csi_buffers,
+        calib_buffer, ul_zf_matrices, dl_zf_matrices, stats);
 
     size_t start_tsc = rdtsc();
     size_t num_tasks = 0;


### PR DESCRIPTION
We use two sets of queues instead of the special decode queue. This method eliminates manual task movement from the normal decode queue to the special decode queue. We also use two complete_task_queue to enforce the dequeue order in the manager. 

The Doer interfaces are simplified to remove the queues and tokens. This change allows the same class objects to dequeue from different queues. 