### PR TITLE
Update the git post-checkout for CI falcon https

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -3,7 +3,7 @@
 
 echo "Starting post-checkout hook ..."
 BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
-CI_BUILD_STATUS_BADGE="[![Build Status](https://4489496cb62a.ngrok.io/buildStatus/icon?job=github_public_agora%2F${BRANCH_NAME})](https://4489496cb62a.ngrok.io/job/github_public_agora/job/${BRANCH_NAME}/)"
+CI_BUILD_STATUS_BADGE="[![Build Status](https://falcon.ecg.rice.edu:443/buildStatus/icon?job=github_public_agora%2F${BRANCH_NAME})](https://falcon.ecg.rice.edu:443/job/github_public_agora/job/${BRANCH_NAME}/)"
 echo $BRANCH_NAME
 echo $CI_BUILD_STATUS_BADGE
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://falcon.ecg.rice.edu:443/buildStatus/icon?job=github_public_agora%2Fdevelop)](https://falcon.ecg.rice.edu:443/job/github_public_agora/job/develop/)
+[![Build Status](https://falcon.ecg.rice.edu:443/buildStatus/icon?job=github_public_agora%2Fupdate-git-hook)](https://falcon.ecg.rice.edu:443/job/github_public_agora/job/update-git-hook/)
 
 Agora is a complete software realization of real-time massive MIMO baseband processing. 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://falcon.ecg.rice.edu:443/buildStatus/icon?job=github_public_agora%2Fupdate-git-hook)](https://falcon.ecg.rice.edu:443/job/github_public_agora/job/update-git-hook/)
+[![Build Status](https://falcon.ecg.rice.edu:443/buildStatus/icon?job=github_public_agora%2Fdevelop)](https://falcon.ecg.rice.edu:443/job/github_public_agora/job/develop/)
 
 Agora is a complete software realization of real-time massive MIMO baseband processing. 
 


### PR DESCRIPTION
Update the git post-checkout hook for the CI build status badge to use falcon https. 

Closes #274