### PR TITLE
Pr dpdk compilefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,8 @@ We provide a high performance [packet generator](simulator) to emulate the RRU. 
    * In another terminal, run  `./build/sender --num_threads=2 --core_offset=1 --frame_duration=5000 --enable_slow_start=1 --conf_file=data/tddconfig-sim-ul.json` to start the emulated RRU 
      with uplink configuration.
    * The above steps use Linux networking stack for packet I/O. Agora also supports using DPDK
-   to bypass the kernel for packet I/O. To enable DPDK, run `cmake -DUSE_DPDK=1 ..; make -j` to 
-   rebuild code for Mellanox NICs; for Intel NICs, run `cmake -DUSE_DPDK=1 -DUSE_MLX_NIC=0 ..; make -j` 
+   to bypass the kernel for packet I/O. To enable DPDK, run `cmake .. -DUSE_DPDK=1; make -j` to 
+   rebuild code for Mellanox NICs; for Intel NICs, run `cmake .. -DUSE_DPDK=1 -DUSE_MLX_NIC=0; make -j` 
    to exclude Mellanox libraries in the build.
    When running the emulated RRU with DPDK, it is required to set the MAC address
      of the NIC used by Agora. To do this, pass `--server_mac_addr=` to

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ We provide a high performance [packet generator](simulator) to emulate the RRU. 
      with uplink configuration.
    * The above steps use Linux networking stack for packet I/O. Agora also supports using DPDK
    to bypass the kernel for packet I/O. To enable DPDK, run `cmake -DUSE_DPDK=1 ..; make -j` to 
-   rebuild code for Mellanox NICs; for Intel NICs, run `cmake .. -DUSE_DPDK=1 -DUSE_MLX_NIC=0; make -j` 
+   rebuild code for Mellanox NICs; for Intel NICs, run `cmake -DUSE_DPDK=1 -DUSE_MLX_NIC=0 ..; make -j` 
    to exclude Mellanox libraries in the build.
    When running the emulated RRU with DPDK, it is required to set the MAC address
      of the NIC used by Agora. To do this, pass `--server_mac_addr=` to

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://falcon.ecg.rice.edu:443/buildStatus/icon?job=github_public_agora%2Fdpdk-develop)](https://falcon.ecg.rice.edu:443/job/github_public_agora/job/dpdk-develop/)
+[![Build Status](https://falcon.ecg.rice.edu:443/buildStatus/icon?job=github_public_agora%2Fpr-dpdk-compilefix)](https://falcon.ecg.rice.edu:443/job/github_public_agora/job/pr-dpdk-compilefix/)
 
 Agora is a complete software realization of real-time massive MIMO baseband processing. 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://falcon.ecg.rice.edu:443/buildStatus/icon?job=github_public_agora%2Fdevelop)](https://falcon.ecg.rice.edu:443/job/github_public_agora/job/develop/)
+[![Build Status](https://falcon.ecg.rice.edu:443/buildStatus/icon?job=github_public_agora%2Fdpdk-develop)](https://falcon.ecg.rice.edu:443/job/github_public_agora/job/dpdk-develop/)
 
 Agora is a complete software realization of real-time massive MIMO baseband processing. 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://falcon.ecg.rice.edu:443/buildStatus/icon?job=github_public_agora%2Fpr-dpdk-compilefix)](https://falcon.ecg.rice.edu:443/job/github_public_agora/job/pr-dpdk-compilefix/)
+[![Build Status](https://falcon.ecg.rice.edu:443/buildStatus/icon?job=github_public_agora%2Fdevelop)](https://falcon.ecg.rice.edu:443/job/github_public_agora/job/develop/)
 
 Agora is a complete software realization of real-time massive MIMO baseband processing. 
 
@@ -94,7 +94,7 @@ We provide a high performance [packet generator](simulator) to emulate the RRU. 
    * In another terminal, run  `./build/sender --num_threads=2 --core_offset=1 --frame_duration=5000 --enable_slow_start=1 --conf_file=data/tddconfig-sim-ul.json` to start the emulated RRU 
      with uplink configuration.
    * The above steps use Linux networking stack for packet I/O. Agora also supports using DPDK
-   to bypass the kernel for packet I/O. To enable DPDK, run `cmake .. -DUSE_DPDK=1; make -j` to 
+   to bypass the kernel for packet I/O. To enable DPDK, run `cmake -DUSE_DPDK=1 ..; make -j` to 
    rebuild code for Mellanox NICs; for Intel NICs, run `cmake .. -DUSE_DPDK=1 -DUSE_MLX_NIC=0; make -j` 
    to exclude Mellanox libraries in the build.
    When running the emulated RRU with DPDK, it is required to set the MAC address

--- a/simulator/sender.h
+++ b/simulator/sender.h
@@ -27,7 +27,7 @@
 #include "symbols.h"
 #include "utils.h"
 
-#ifdef USE_DPDK
+#if defined(USE_DPDK)
 #include <netinet/ether.h>
 
 #include "dpdk_transport.h"
@@ -145,7 +145,7 @@ class Sender {
 
   std::vector<std::thread> threads_;
 
-#ifdef USE_DPDK
+#if defined(USE_DPDK)
   struct rte_mempool* mbuf_pool_;
   uint32_t bs_rru_addr_;     // IPv4 address of this data sender
   uint32_t bs_server_addr_;  // IPv4 address of the remote target Agora server

--- a/src/agora/txrx/txrx.h
+++ b/src/agora/txrx/txrx.h
@@ -25,7 +25,7 @@
 #include "udp_client.h"
 #include "udp_server.h"
 
-#ifdef USE_DPDK
+#if defined(USE_DPDK)
 #include "dpdk_transport.h"
 #endif
 
@@ -54,7 +54,7 @@ class PacketTXRX {
              moodycamel::ProducerToken** tx_ptoks);
   ~PacketTXRX();
 
-#ifdef USE_DPDK
+#if defined(USE_DPDK)
   // At thread [tid], receive packets from the NIC and enqueue them to the
   // master thread
   uint16_t DpdkRecv(int tid, uint16_t port_id, uint16_t queue_id,
@@ -119,7 +119,7 @@ class PacketTXRX {
   std::vector<std::unique_ptr<UDPServer>> udp_servers_;
   std::vector<std::unique_ptr<UDPClient>> udp_clients_;
 
-#ifdef USE_DPDK
+#if defined(USE_DPDK)
   uint32_t bs_rru_addr;     // IPv4 address of the simulator sender
   uint32_t bs_server_addr;  // IPv4 address of the Agora server
   struct rte_mempool* mbuf_pool;

--- a/src/common/dpdk_transport.h
+++ b/src/common/dpdk_transport.h
@@ -26,13 +26,13 @@
 
 #include "utils.h"
 
-#define RX_RING_SIZE (2048)
-#define TX_RING_SIZE (2048)
+static constexpr size_t kRxRingSize = 2048;
+static constexpr size_t kTxRingSize = 2048;
+static constexpr size_t kNumMBufs = ((32 * 1024) - 1);
+static constexpr size_t kMBufCacheSize = 128;
 
-#define NUM_MBUFS ((32 * 1024) - 1)
-#define MBUF_CACHE_SIZE (128)
-
-#define JUMBO_FRAME_MAX_SIZE (0x2600)  // allow max jumbo frame 9.5 KB
+// allow max jumbo frame 9.5 KB
+static constexpr size_t kJumboFrameMaxSize = 0x2600;
 /// Maximum number of packets received in rx_burst
 static constexpr size_t kRxBatchSize = 16;
 static constexpr size_t kTxBatchSize = 1;
@@ -48,34 +48,33 @@ class DpdkTransport {
   DpdkTransport();
   ~DpdkTransport();
 
-  static int nic_init(uint16_t port, struct rte_mempool* mbuf_pool,
-                      int thread_num, size_t pkt_len = JUMBO_FRAME_MAX_SIZE);
+  static int NicInit(uint16_t port, struct rte_mempool* mbuf_pool,
+                     int thread_num, size_t pkt_len = kJumboFrameMaxSize);
 
   // Steer the flow [src_ip, dest_ip, src_port, dst_port] arriving on
   // [port_id] to RX queue [rx_q]
-  static void install_flow_rule(uint16_t port_id, uint16_t rx_q,
-                                uint32_t src_ip, uint32_t dest_ip,
-                                uint16_t src_port, uint16_t dst_port);
+  static void InstallFlowRule(uint16_t port_id, uint16_t rx_q, uint32_t src_ip,
+                              uint32_t dest_ip, uint16_t src_port,
+                              uint16_t dst_port);
 
-  static void fastMemcpy(void* pvDest, void* pvSrc, size_t nBytes);
-  static void print_pkt(int src_ip, int dst_ip, uint16_t src_port,
-                        uint16_t dst_port, int len, int tid);
+  static void FastMemcpy(void* pvDest, void* pvSrc, size_t nBytes);
+  static void PrintPkt(int src_ip, int dst_ip, uint16_t src_port,
+                       uint16_t dst_port, int len, int tid);
 
   /// Return a string representation of this packet
-  static std::string pkt_to_string(const rte_mbuf* pkt);
+  static std::string PktToString(const rte_mbuf* pkt);
 
   /// Allocate and return a fresh rte_mbuf with Ethernet, IPv4, and UDP
   /// header filled
-  static rte_mbuf* alloc_udp(rte_mempool* mbuf_pool,
-                             rte_ether_addr src_mac_addr,
-                             rte_ether_addr dst_mac_addr, uint32_t src_ip_addr,
-                             uint32_t dst_ip_addr, uint16_t src_udp_port,
-                             uint16_t dst_udp_port, size_t buffer_length);
+  static rte_mbuf* AllocUdp(rte_mempool* mbuf_pool, rte_ether_addr src_mac_addr,
+                            rte_ether_addr dst_mac_addr, uint32_t src_ip_addr,
+                            uint32_t dst_ip_addr, uint16_t src_udp_port,
+                            uint16_t dst_udp_port, size_t buffer_length);
 
   /// Init dpdk on core [core_offset:core_offset+thread_num]
-  static void dpdk_init(uint16_t core_offset, size_t thread_num);
-  static rte_mempool* create_mempool(
-      size_t num_ports, size_t packet_length = JUMBO_FRAME_MAX_SIZE);
+  static void DpdkInit(uint16_t core_offset, size_t thread_num);
+  static rte_mempool* CreateMempool(size_t num_ports,
+                                    size_t packet_length = kJumboFrameMaxSize);
 };
 
 #endif  // DPDK_TRANSPORT_H_

--- a/src/common/symbols.h
+++ b/src/common/symbols.h
@@ -110,7 +110,7 @@ enum class PrintType : int {
 static constexpr bool kEnableThreadPinning = true;
 
 #define BIGSTATION 0
-#ifdef USE_DPDK
+#if defined(USE_DPDK)
 static constexpr bool kUseDPDK = true;
 #else
 static constexpr bool kUseDPDK = false;


### PR DESCRIPTION
Fix for compiling with the USE_DPDK flag.

Changed the #ifdef to #if defined() because defined can be used in compound expressions (but not necessary in these cases).
Updated the dpdk functions to align with our coding standards.