### PR TITLE
Bug Fix for MacThread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,11 +146,13 @@ set(MAC_CLIENT_SOURCES
   src/mac/mac_sender.cc
   src/mac/mac_receiver.cc
   src/mac/video_receiver.cc
+  src/mac/file_receiver.cc
   src/mac/mac_client.cc)
 set(MAC_BS_SOURCES
   src/mac/mac_sender.cc
   src/mac/mac_receiver.cc
   src/mac/video_receiver.cc
+  src/mac/file_receiver.cc
   src/mac/mac_basestation.cc)
 
 # Argos support

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,10 +145,12 @@ endif()
 set(MAC_CLIENT_SOURCES
   src/mac/mac_sender.cc
   src/mac/mac_receiver.cc
+  src/mac/video_receiver.cc
   src/mac/mac_client.cc)
 set(MAC_BS_SOURCES
   src/mac/mac_sender.cc
   src/mac/mac_receiver.cc
+  src/mac/video_receiver.cc
   src/mac/mac_basestation.cc)
 
 # Argos support

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://falcon.ecg.rice.edu:443/buildStatus/icon?job=github_public_agora%2Fmaster)](https://falcon.ecg.rice.edu:443/job/github_public_agora/job/master/)
+[![Build Status](https://falcon.ecg.rice.edu:443/buildStatus/icon?job=github_public_agora%2Fvideo-demo)](https://falcon.ecg.rice.edu:443/job/github_public_agora/job/video-demo/)
 
 Agora is a complete software realization of real-time massive MIMO baseband processing. 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://falcon.ecg.rice.edu:443/buildStatus/icon?job=github_public_agora%2Fvideo-demo)](https://falcon.ecg.rice.edu:443/job/github_public_agora/job/video-demo/)
+[![Build Status](https://falcon.ecg.rice.edu:443/buildStatus/icon?job=github_public_agora%2Fdevelop)](https://falcon.ecg.rice.edu:443/job/github_public_agora/job/develop/)
 
 Agora is a complete software realization of real-time massive MIMO baseband processing. 
 

--- a/src/agora/agora.cc
+++ b/src/agora/agora.cc
@@ -479,8 +479,6 @@ void Agora::Start() {
         case EventType::kPacketFromMac: {
           size_t frame_id = rx_tag_t(event.tags_[0]).offset_;
 
-          std::printf("EventType::kPacketFromMac: frame %zu\n", frame_id);
-
           bool last_ue = this->mac_to_phy_counters_.CompleteTask(frame_id, 0);
           if (last_ue == true) {
             // schedule this frame's encoding
@@ -499,7 +497,6 @@ void Agora::Start() {
             this->mac_to_phy_counters_.Reset(frame_id);
             PrintPerFrameDone(PrintType::kPacketFromMac, frame_id);
           }
-
         } break;
 
         case EventType::kEncode: {

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -624,8 +624,8 @@ void Config::GenData() {
       throw std::runtime_error("Config: Failed to open antenna file");
     }
 
-    for (size_t i = this->frame_.ClientUlPilotSymbols(); i < this->frame_.NumULSyms();
-         i++) {
+    for (size_t i = this->frame_.ClientUlPilotSymbols();
+         i < this->frame_.NumULSyms(); i++) {
       if (std::fseek(fd, (data_bytes_num_persymbol_ * this->ue_ant_offset_),
                      SEEK_CUR) != 0) {
         MLPD_ERROR(" *** Error: failed to seek propertly (pre) into %s file\n",
@@ -670,8 +670,8 @@ void Config::GenData() {
       throw std::runtime_error("Config: Failed to open dl antenna file");
     }
 
-    for (size_t i = this->frame_.ClientDlPilotSymbols(); i < this->frame_.NumDLSyms();
-         i++) {
+    for (size_t i = this->frame_.ClientDlPilotSymbols();
+         i < this->frame_.NumDLSyms(); i++) {
       for (size_t j = 0; j < this->ue_ant_num_; j++) {
         size_t r = std::fread(this->dl_bits_[i] + j * num_bytes_per_ue_pad,
                               sizeof(int8_t), data_bytes_num_persymbol_, fd);

--- a/src/common/udp_server.h
+++ b/src/common/udp_server.h
@@ -22,6 +22,8 @@
 #include <unistd.h>
 
 #include <cstring> /* std::strerror, std::memset, std::memcpy */
+#include <map>
+#include <mutex>
 #include <stdexcept>
 
 /// Basic UDP server class based on OS sockets that supports receiving messages

--- a/src/common/udp_server.h
+++ b/src/common/udp_server.h
@@ -37,20 +37,12 @@ class UDPServer {
     if (kDebugPrintUdpServerInit) {
       std::printf("Creating UDP server listening at port %d\n", port);
     }
-    sock_fd_ = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    sock_fd_ = socket(AF_INET, SOCK_DGRAM | SOCK_NONBLOCK, IPPROTO_UDP);
     if (sock_fd_ == -1) {
       throw std::runtime_error("UDPServer: Failed to create local socket.");
     }
 
-    // Set the socket as non-blocking
-    int flags = fcntl(sock_fd_, F_GETFL);
-    if (flags == -1) {
-      throw std::runtime_error("UDPServer: fcntl failed to get flags");
-    }
-    int ret = fcntl(sock_fd_, F_SETFL, flags | O_NONBLOCK);
-    if (ret == -1) {
-      throw std::runtime_error("UDPServer: fcntl failed to set nonblock");
-    }
+    int ret = 0;
 
     // Set buffer size
     if (rx_buffer_size != 0) {
@@ -65,7 +57,7 @@ class UDPServer {
     serveraddr.sin_family = AF_INET;
     serveraddr.sin_addr.s_addr = htonl(INADDR_ANY);
     serveraddr.sin_port = htons(static_cast<unsigned short>(port));
-    std::memset(serveraddr.sin_zero, 0, sizeof(serveraddr.sin_zero));
+    std::memset(serveraddr.sin_zero, 0u, sizeof(serveraddr.sin_zero));
 
     ret = bind(sock_fd_, reinterpret_cast<struct sockaddr*>(&serveraddr),
                sizeof(serveraddr));
@@ -104,16 +96,18 @@ class UDPServer {
    */
   ssize_t Recv(uint8_t* buf, size_t len) const {
     ssize_t ret = recv(sock_fd_, static_cast<void*>(buf), len, 0);
+
     if (ret == -1) {
-      if (errno == EAGAIN || ret == EWOULDBLOCK) {
+      if ((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
         // These errors mean that there's no data to receive
-        return 0;
+        ret = 0;
       } else {
         std::fprintf(stderr,
                      "UDPServer: recv() failed with unexpected error %s\n",
                      std::strerror(errno));
-        return ret;
       }
+    } else if (ret == 0) {
+      std::fprintf(stderr, "UDPServer: recv() failed with return of 0\n");
     }
     return ret;
   }
@@ -160,27 +154,21 @@ class UDPServer {
       rem_addrinfo = remote_itr->second;
     }
 
-    // struct sockaddr_in remote_addr;
-    // remote_addr.sin_family = AF_INET;
-    // remote_addr.sin_port = htons(src_port);
-    // remote_addr.sin_addr.s_addr = inet_addr(src_address.c_str());
-    // std::memset(remote_addr.sin_zero, 0, sizeof(remote_addr.sin_zero));
-    // socklen_t addrlen = sizeof(remote_addr);
-
     socklen_t addrlen = rem_addrinfo->ai_addrlen;
     ssize_t ret = recvfrom(sock_fd_, static_cast<void*>(buf), len, 0,
                            rem_addrinfo->ai_addr, &addrlen);
 
     if (ret == -1) {
-      if (errno == EAGAIN || ret == EWOULDBLOCK) {
+      if ((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
         // These errors mean that there's no data to receive
-        return 0;
+        ret = 0;
       } else {
         std::fprintf(stderr,
                      "UDPServer: recvfrom() failed with unexpected error %s\n",
                      std::strerror(errno));
-        return ret;
       }
+    } else if (ret == 0) {
+      std::fprintf(stderr, "UDPServer: recv() failed with return of 0\n");
     }
     return ret;
   }
@@ -190,14 +178,26 @@ class UDPServer {
    * will now block
    */
   void MakeBlocking(size_t timeout_sec = 0) {
-    int flags = fcntl(sock_fd_, F_GETFL);
-    if (flags == -1) {
+    int current_flags = fcntl(sock_fd_, F_GETFL);
+    if (current_flags == -1) {
       throw std::runtime_error("UDPServer: fcntl failed to get flags");
     }
-    flags = flags & (~O_NONBLOCK);
-    int ret = fcntl(sock_fd_, F_SETFL, flags);
-    if (ret == -1) {
-      throw std::runtime_error("UDPServer: fcntl failed to set blocking");
+    int desired_flags = current_flags & (~O_NONBLOCK);
+
+    if (desired_flags != current_flags) {
+      int fcntl_status = fcntl(sock_fd_, F_SETFL, desired_flags);
+      if (fcntl_status == -1) {
+        throw std::runtime_error("UDPServer: fcntl failed to set blocking");
+      }
+
+      //Verify the flags were properly set
+      current_flags = fcntl(sock_fd_, F_GETFL);
+      if (current_flags == -1) {
+        throw std::runtime_error("UDPServer: fcntl failed to get flags");
+      } else if (current_flags != desired_flags) {
+        throw std::runtime_error(
+            "UDPServer: failed to set UDP socket to blocking");
+      }
     }
 
     // Set timeout
@@ -205,8 +205,9 @@ class UDPServer {
       struct timeval tv;
       tv.tv_sec = timeout_sec;
       tv.tv_usec = 0;
-      ret = setsockopt(sock_fd_, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
-      if (ret != 0) {
+      int opt_status =
+          setsockopt(sock_fd_, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+      if (opt_status != 0) {
         throw std::runtime_error("UDPServer: Failed to set timeout.");
       }
     }

--- a/src/mac/file_receiver.cc
+++ b/src/mac/file_receiver.cc
@@ -1,0 +1,82 @@
+/**
+ * @file file_receiver.cc
+ * @brief Implementation file for the FileReceiver class
+ */
+
+#include "file_receiver.h"
+
+#include <cassert>
+#include <cstring>
+
+static constexpr size_t kMaxReadAttempts = 2;
+
+FileReceiver::FileReceiver(std::string &file_name)
+    : file_name_(file_name), data_availble_(0), data_start_offset_(0) {
+  ///\todo Make sure that the file size is > FileReceiver::kFileStreamRxSize
+  data_stream_.open(file_name_, (std::ifstream::in | std::ifstream::binary));
+  assert(data_stream_.is_open() == true);
+}
+
+FileReceiver::~FileReceiver() {
+  if (data_stream_.is_open() == true) {
+    data_stream_.close();
+  }
+}
+
+void FileReceiver::Load(char *destination, size_t num_load_bytes) {
+  const size_t file_read_size =
+      std::max(FileReceiver::kFileStreamRxSize, num_load_bytes);
+  //Make sure the local buffer is large enough to perform the correct read
+  assert(file_read_size <= local_rx_buffer_.size());
+  assert(data_stream_.is_open() == true);
+  if (num_load_bytes > data_availble_) {
+    //Check for potential local buffer wrap-around
+    if ((data_availble_ + data_start_offset_ + file_read_size) >
+        local_rx_buffer_.size()) {
+      memcpy(&local_rx_buffer_.at(0), &local_rx_buffer_.at(data_start_offset_),
+             data_availble_);
+      data_start_offset_ = 0;
+    }
+
+    size_t data_read = 0;
+    size_t read_attempts = 0;
+    //Read until we have enough bytes, limit to kMaxReadAttempts
+    while ((data_read < file_read_size) && (read_attempts < kMaxReadAttempts)) {
+      data_stream_.read(reinterpret_cast<char *>(&local_rx_buffer_.at(
+                            data_start_offset_ + data_availble_ + data_read)),
+                        file_read_size - data_read);
+
+      data_read += data_stream_.gcount();
+      std::printf("[VideoReceiver] data received: %zu:%zu : \n", data_read,
+                  file_read_size);
+
+      // Check for eof after read
+      if (data_stream_.eof()) {
+        std::printf(
+            "[FileReceiver]: ***EndofFileStream - requested %zu read count "
+            "%zu\n",
+            file_read_size, data_read);
+        data_stream_.close();
+        data_stream_.open(file_name_,
+                          std::ifstream::in | std::ifstream::binary);
+      }
+
+      //Check for errors on the stream
+      if (data_stream_) {
+        throw std::runtime_error("[FileReceiver] data stream errors\n");
+      }
+      read_attempts++;
+    }
+    data_availble_ += data_read;
+  }
+
+  if (num_load_bytes > data_availble_) {
+    throw std::runtime_error("[FileReceiver] failed to load enough data\n");
+  } else {
+    //Copy data from local buffer to requested memory location
+    memcpy(destination, &local_rx_buffer_.at(data_start_offset_),
+           num_load_bytes);
+    std::printf("[Receive Server] Data loaded: %zu\n", num_load_bytes);
+    data_start_offset_ += num_load_bytes;
+  }
+}

--- a/src/mac/file_receiver.h
+++ b/src/mac/file_receiver.h
@@ -1,0 +1,38 @@
+/**
+ * @file file_receiver.h
+ * @brief Declaration file for the FileReceiver class
+ */
+#ifndef FILE_RECEIVER_H_
+#define FILE_RECEIVER_H_
+
+#include <array>
+#include <fstream>
+#include <ios>
+#include <iostream>
+#include <string>
+
+#include "mac_data_receiver.h"
+
+/**
+ * @brief The File Receiver class creates a binary file source for Agora
+ */
+class FileReceiver : public MacDataReceiver {
+ public:
+  static constexpr size_t kFileStreamRxSize = (2048u);
+  static constexpr size_t kFileStreamLocalRxBufSize = (kFileStreamRxSize * 10u);
+
+  FileReceiver(std::string &file_name);
+  ~FileReceiver();
+
+  void Load(char *destination, size_t num_load_bytes) override final;
+
+ private:
+  std::string file_name_;
+  std::ifstream data_stream_;
+  std::array<uint8_t, FileReceiver::kFileStreamLocalRxBufSize> local_rx_buffer_;
+
+  size_t data_availble_;
+  size_t data_start_offset_;
+};
+
+#endif  // FILE_RECEIVER_H_

--- a/src/mac/file_receiver.h
+++ b/src/mac/file_receiver.h
@@ -31,7 +31,7 @@ class FileReceiver : public MacDataReceiver {
   std::ifstream data_stream_;
   std::array<uint8_t, FileReceiver::kFileStreamLocalRxBufSize> local_rx_buffer_;
 
-  size_t data_availble_;
+  size_t data_available_;
   size_t data_start_offset_;
 };
 

--- a/src/mac/file_receiver.h
+++ b/src/mac/file_receiver.h
@@ -24,7 +24,7 @@ class FileReceiver : public MacDataReceiver {
   FileReceiver(std::string &file_name);
   ~FileReceiver();
 
-  void Load(char *destination, size_t num_load_bytes) override final;
+  size_t Load(char *destination, size_t num_load_bytes) override final;
 
  private:
   std::string file_name_;

--- a/src/mac/mac_data_receiver.h
+++ b/src/mac/mac_data_receiver.h
@@ -1,0 +1,21 @@
+/**
+ * @file mac_data_receiver.h
+ * @brief Declaration file for the MacDataReceiver interface class
+ */
+#ifndef MAC_DATA_RECEIVER_H_
+#define MAC_DATA_RECEIVER_H_
+
+#include <cstdint>
+
+/**
+ * @brief The MacDataReceiver interface class
+ */
+class MacDataReceiver {
+ public:
+  virtual void Load(char *destination, size_t num_load_bytes) = 0;
+
+ protected:
+  inline MacDataReceiver(){};
+};
+
+#endif  // MAC_DATA_RECEIVER_H_

--- a/src/mac/mac_data_receiver.h
+++ b/src/mac/mac_data_receiver.h
@@ -12,7 +12,7 @@
  */
 class MacDataReceiver {
  public:
-  virtual void Load(char *destination, size_t num_load_bytes) = 0;
+  virtual size_t Load(char *destination, size_t num_load_bytes) = 0;
 
  protected:
   inline MacDataReceiver(){};

--- a/src/mac/mac_receiver.cc
+++ b/src/mac/mac_receiver.cc
@@ -8,7 +8,7 @@
 #include "udp_client.h"
 #include "udp_server.h"
 
-#define STREAM_UDP_DATA
+//#define STREAM_UDP_DATA
 static constexpr char kVideoStreamingAddr[] = "10.238.200.112";
 static constexpr uint16_t kVideoStreamingPort = 1235u;
 

--- a/src/mac/mac_receiver.cc
+++ b/src/mac/mac_receiver.cc
@@ -5,7 +5,12 @@
 #include "mac_receiver.h"
 
 #include "signal_handler.h"
+#include "udp_client.h"
 #include "udp_server.h"
+
+#define STREAM_UDP_DATA
+static constexpr char kVideoStreamingAddr[] = "10.238.200.112";
+static constexpr uint16_t kVideoStreamingPort = 1235u;
 
 static const bool kDebugMacReceiver = true;
 
@@ -41,6 +46,10 @@ void* MacReceiver::LoopRecv(size_t tid) {
   auto udp_server =
       std::make_unique<UDPServer>(server_tx_port_ + ue_id, sock_buf_size);
 
+#if defined(STREAM_UDP_DATA)
+  auto udp_video_streamer = std::make_unique<UDPClient>();
+#endif
+
   udp_server->MakeBlocking(1);
 
   // TODO: Should each UE have a rx port?
@@ -61,6 +70,12 @@ void* MacReceiver::LoopRecv(size_t tid) {
       throw std::runtime_error("Receiver: recv failed");
     } else if (static_cast<size_t>(recvlen) == packet_length) {
       // Write the data packet to a file or push to file writter queue
+#if defined(STREAM_UDP_DATA)
+      udp_video_streamer->Send(std::string(kVideoStreamingAddr),
+                               kVideoStreamingPort, &rx_buffer[0u],
+                               packet_length);
+#endif
+
       if (kDebugMacReceiver) {
         std::printf("MacReceiver: Thread %zu,  Received Data:", tid);
         for (size_t i = 0; i < packet_length; i++) {

--- a/src/mac/mac_sender.cc
+++ b/src/mac/mac_sender.cc
@@ -12,7 +12,7 @@
 #include "udp_client.h"
 #include "video_receiver.h"
 
-//#define USE_UDP_DATA_SOURCE
+#define USE_UDP_DATA_SOURCE
 
 static constexpr bool kDebugPrintSender = false;
 static constexpr size_t kFrameLoadAdvance = 10;
@@ -383,10 +383,10 @@ void* MacSender::DataUpdateThread(size_t tid) {
             sched_getcpu());
 
 #if defined(USE_UDP_DATA_SOURCE)
-  auto data_source = std::make_unique<FileReceiver>(data_filename_);
-#else
   auto data_source =
       std::make_unique<VideoReceiver>(VideoReceiver::kVideoStreamRxPort);
+#else
+  auto data_source = std::make_unique<FileReceiver>(data_filename_);
 #endif
 
   // Init the data buffers

--- a/src/mac/mac_sender.cc
+++ b/src/mac/mac_sender.cc
@@ -4,14 +4,12 @@
  */
 #include "mac_sender.h"
 
-#include <fstream>
-#include <ios>
-#include <iostream>
 #include <thread>
 
 #include "datatype_conversion.h"
 #include "logger.h"
 #include "udp_client.h"
+#include "video_receiver.h"
 
 static constexpr bool kDebugPrintSender = false;
 static constexpr size_t kFrameLoadAdvance = 10;
@@ -414,7 +412,7 @@ void* MacSender::DataUpdateThread(size_t tid) {
   return nullptr;
 }
 
-void MacSender::UpdateTxBuffer(VideoReceiver* video, gen_tag_t tag) {
+void MacSender::UpdateTxBuffer(MacDataReceiver* data_source, gen_tag_t tag) {
   // Load a frames worth of data
   uint8_t* mac_packet_location = tx_buffers_[TagToTxBuffersIndex(tag)];
 
@@ -425,7 +423,7 @@ void MacSender::UpdateTxBuffer(VideoReceiver* video, gen_tag_t tag) {
     pkt->ue_id_ = tag.ue_id_;
 
     // Read a MacPayload into the data section
-    video->Load(pkt->data_, cfg_->MacPayloadLength());
+    data_source->Load(pkt->data_, cfg_->MacPayloadLength());
     // TODO MacPacketLength should be the size of the mac packet but is not.
     mac_packet_location = mac_packet_location +
                           (cfg_->MacPacketLength() + MacPacket::kOffsetOfData);

--- a/src/mac/mac_sender.cc
+++ b/src/mac/mac_sender.cc
@@ -12,7 +12,7 @@
 #include "udp_client.h"
 #include "video_receiver.h"
 
-#define USE_UDP_DATA_SOURCE
+//#define USE_UDP_DATA_SOURCE
 
 static constexpr bool kDebugPrintSender = false;
 static constexpr size_t kFrameLoadAdvance = 10;
@@ -208,9 +208,8 @@ void* MacSender::MasterThread(size_t /*unused*/) {
       frame_data_count.at(comp_frame_slot)++;
 
       if (kDebugPrintSender) {
-        std::printf("MacSender: Checking frame %d : %zu : %zu\n",
-                    ctag.frame_id_, comp_frame_slot,
-                    frame_data_count.at(comp_frame_slot));
+        MLPD_INFO("MacSender: Checking frame %d : %zu : %zu\n", ctag.frame_id_,
+                  comp_frame_slot, frame_data_count.at(comp_frame_slot));
       }
       // Check to see if the current frame is finished (UeNum / UeAntNum)
       if (frame_data_count.at(comp_frame_slot) == cfg_->UeAntNum()) {
@@ -221,9 +220,9 @@ void* MacSender::MasterThread(size_t /*unused*/) {
         size_t next_frame_id = ctag.frame_id_ + 1;
         if ((kDebugSenderReceiver == true) ||
             (kDebugPrintPerFrameDone == true)) {
-          std::printf("MacSender: Tx frame %d in %.2f ms, next frame %zu\n",
-                      ctag.frame_id_, (frame_end_us - frame_start_us) / 1000.0,
-                      next_frame_id);
+          MLPD_INFO("MacSender: Tx frame %d in %.2f ms, next frame %zu\n",
+                    ctag.frame_id_, (frame_end_us - frame_start_us) / 1000.0,
+                    next_frame_id);
         }
         this->frame_end_[(ctag.frame_id_ % kNumStatsFrames)] = frame_end_us;
 
@@ -319,7 +318,9 @@ void* MacSender::WorkerThread(size_t tid) {
 
         if (kDebugSenderReceiver) {
           std::printf(
-              "Thread %zu (tag = %s) transmit frame %d, radio %zu, TX time: "
+              "MacSender: Thread %zu (tag = %s) transmit frame %d, radio %zu, "
+              "TX "
+              "time: "
               "%.3f us\n",
               tid, gen_tag_t(tag).ToString().c_str(), tag.frame_id_, cur_radio,
               GetTime::CyclesToUs(GetTime::Rdtsc() - start_tsc_send,
@@ -334,10 +335,12 @@ void* MacSender::WorkerThread(size_t tid) {
           double byte_len = cfg_->PacketLength() * ant_num_this_thread *
                             max_symbol_id * 1000.f;
           double diff = end - begin;
-          std::printf("Thread %zu send %zu frames in %f secs, tput %f Mbps\n",
-                      (size_t)tid,
-                      total_tx_packets / (ant_num_this_thread * max_symbol_id),
-                      diff / 1e6, byte_len * 8 * 1e6 / diff / 1024 / 1024);
+          std::printf(
+              "MacSender: Thread %zu send %zu frames in %f secs, tput %f "
+              "Mbps\n",
+              (size_t)tid,
+              total_tx_packets / (ant_num_this_thread * max_symbol_id),
+              diff / 1e6, byte_len * 8 * 1e6 / diff / 1024 / 1024);
           begin = GetTime::GetTimeUs();
           total_tx_packets_rolling = 0;
         }
@@ -430,20 +433,26 @@ void MacSender::UpdateTxBuffer(MacDataReceiver* data_source, gen_tag_t tag) {
     pkt->ue_id_ = tag.ue_id_;
 
     // Read a MacPayload into the data section
-    data_source->Load(pkt->data_, cfg_->MacPayloadLength());
+    size_t loaded_bytes =
+        data_source->Load(pkt->data_, cfg_->MacPayloadLength());
+    if (loaded_bytes != cfg_->MacPayloadLength()) {
+      MLPD_ERROR(
+          "MacSender [frame %d, ue %d]: Data not available to be loaded\n",
+          tag.frame_id_, tag.ant_id_);
+    }
     // TODO MacPacketLength should be the size of the mac packet but is not.
     mac_packet_location = mac_packet_location +
                           (cfg_->MacPacketLength() + MacPacket::kOffsetOfData);
   }
-  std::printf("MacSender: Loading packet for frame %d, ue %d, bytes %zu\n",
-              tag.frame_id_, tag.ant_id_,
-              cfg_->MacPayloadLength() * packets_per_frame_);
+  MLPD_INFO("MacSender [frame %d, ue %d]: Loaded packet for bytes %zu\n",
+            tag.frame_id_, tag.ant_id_,
+            cfg_->MacPayloadLength() * packets_per_frame_);
 }
 
 void MacSender::WriteStatsToFile(size_t tx_frame_count) const {
   std::string cur_directory = TOSTRING(PROJECT_DIRECTORY);
   std::string filename = cur_directory + "/data/tx_result.txt";
-  std::printf("Printing sender results to file \"%s\"...\n", filename.c_str());
+  MLPD_INFO("Printing sender results to file \"%s\"...\n", filename.c_str());
 
   std::ofstream debug_file;
   debug_file.open(filename, std::ifstream::out);

--- a/src/mac/mac_sender.h
+++ b/src/mac/mac_sender.h
@@ -13,6 +13,7 @@
 #include "concurrentqueue.h"
 #include "config.h"
 #include "memory_manage.h"
+#include "video_receiver.h"
 
 class MacSender {
  public:
@@ -69,7 +70,7 @@ class MacSender {
   // Launch threads to run worker with thread IDs from tid_start to tid_end
   void CreateWorkerThreads(size_t num_workers);
 
-  void UpdateTxBuffer(std::ifstream& read, gen_tag_t tag);
+  void UpdateTxBuffer(VideoReceiver* video, gen_tag_t tag);
   void WriteStatsToFile(size_t tx_frame_count) const;
 
   void ScheduleFrame(size_t frame);

--- a/src/mac/mac_sender.h
+++ b/src/mac/mac_sender.h
@@ -12,8 +12,8 @@
 
 #include "concurrentqueue.h"
 #include "config.h"
+#include "mac_data_receiver.h"
 #include "memory_manage.h"
-#include "video_receiver.h"
 
 class MacSender {
  public:
@@ -70,7 +70,7 @@ class MacSender {
   // Launch threads to run worker with thread IDs from tid_start to tid_end
   void CreateWorkerThreads(size_t num_workers);
 
-  void UpdateTxBuffer(VideoReceiver* video, gen_tag_t tag);
+  void UpdateTxBuffer(MacDataReceiver* video, gen_tag_t tag);
   void WriteStatsToFile(size_t tx_frame_count) const;
 
   void ScheduleFrame(size_t frame);

--- a/src/mac/mac_thread_basestation.cc
+++ b/src/mac/mac_thread_basestation.cc
@@ -7,6 +7,8 @@
 #include "logger.h"
 #include "utils_ldpc.h"
 
+static constexpr size_t kUdpRxBufferPadding = 2048u;
+
 MacThreadBaseStation::MacThreadBaseStation(
     Config* cfg, size_t core_offset,
     PtrCube<kFrameWnd, kMaxSymbols, kMaxUEs, int8_t>& decoded_buffer,
@@ -44,7 +46,7 @@ MacThreadBaseStation::MacThreadBaseStation(
   }
 
   const size_t udp_pkt_len = cfg_->DlMacDataBytesNumPerframe();
-  udp_pkt_buf_.resize(udp_pkt_len);
+  udp_pkt_buf_.resize(udp_pkt_len + kUdpRxBufferPadding);
 
   // TODO: See if it makes more sense to split up the UE's by port here for
   // client mode.
@@ -53,7 +55,6 @@ MacThreadBaseStation::MacThreadBaseStation(
             udp_server_port);
   udp_server_ = std::make_unique<UDPServer>(
       udp_server_port, udp_pkt_len * kMaxUEs * kMaxPktsPerUE);
-  //udp_server_->MakeBlocking(10);
 
   const size_t udp_control_len = sizeof(RBIndicator);
   udp_control_buf_.resize(udp_control_len);
@@ -205,37 +206,45 @@ void MacThreadBaseStation::SendControlInformation() {
 void MacThreadBaseStation::ProcessUdpPacketsFromApps() {
   if (0 == cfg_->DlMacDataBytesNumPerframe()) return;
 
-  std::memset(&udp_pkt_buf_[0], 0, udp_pkt_buf_.size());
-
   size_t rx_bytes = 0;
-  size_t rx_request_size = udp_pkt_buf_.size();
-  uint8_t* rx_location = &udp_pkt_buf_[0];
-  for (size_t rx_tries = 0; rx_tries < cfg_->DlMacPacketsPerframe();
-       rx_tries++) {
-    ssize_t ret = udp_server_->Recv(rx_location, rx_request_size);
+  size_t rx_bytes_required = cfg_->DlMacDataBytesNumPerframe();
+  const size_t max_recv_attempts = (cfg_->DlMacPacketsPerframe() * 10u);
+  size_t rx_attempts;
+  for (rx_attempts = 0u; rx_attempts < max_recv_attempts; rx_attempts++) {
+    ssize_t ret = udp_server_->Recv(&udp_pkt_buf_.at(rx_bytes),
+                                    udp_pkt_buf_.size() - rx_bytes);
     if (ret == 0) {
-      return;  // No data received
+      MLPD_FRAME("MacThreadBaseStation: No data received\n");
+      if (rx_bytes == 0) {
+        return;  // No data received
+      } else {
+        MLPD_FRAME(
+            "MacThreadBaseStation: No data received but there was data in "
+            "buffer pending %zu : try %zu out of %zu\n",
+            rx_bytes, rx_attempts, max_recv_attempts);
+      }
     } else if (ret < 0) {
       // There was an error in receiving
       MLPD_ERROR("MacThreadBaseStation: Error in reception %zu\n", ret);
       cfg_->Running(false);
       return;
     } else {
-      MLPD_FRAME("MacThreadBaseStation: Received %zu : %zu bytes\n", ret,
-                 rx_request_size);
       rx_bytes += ret;
-      if (rx_bytes == udp_pkt_buf_.size()) {
+      MLPD_TRACE("MacThreadBaseStation: Received %zu : %zu bytes\n", ret,
+                 rx_bytes_required);
+      if (rx_bytes >= rx_bytes_required) {
+        MLPD_FRAME("MacThreadBaseStation rx full frame data %zu\n", rx_bytes);
         break;
       }
-      rx_request_size -= ret;
-      rx_location += ret;
     }
   }
+
   if (rx_bytes != cfg_->DlMacDataBytesNumPerframe()) {
-    MLPD_ERROR("MacThreadBaseStation: Received %zu : %zu bytes\n", rx_bytes,
-               cfg_->DlMacDataBytesNumPerframe());
+    MLPD_ERROR(
+        "MacThreadBaseStation: Received %zu : %zu bytes in %zu attempts\n",
+        rx_bytes, cfg_->DlMacDataBytesNumPerframe(), rx_attempts);
   } else {
-    MLPD_INFO("MacThreadBaseStation: Received Mac Frame Data\n");
+    MLPD_FRAME("MacThreadBaseStation: Received Mac Frame Data\n");
   }
   RtAssert(rx_bytes == cfg_->DlMacDataBytesNumPerframe(),
            "MacThreadBaseStation:ProcessUdpPacketsFromApps incorrect number of "
@@ -320,12 +329,14 @@ void MacThreadBaseStation::RunEventLoop() {
   PinToCoreWithOffset(ThreadType::kWorkerMacTXRX, core_offset_,
                       0 /* thread ID */);
 
+  size_t last_frame_tx_tsc = 0;
+
   while (cfg_->Running() == true) {
     ProcessRxFromPhy();
 
-    if (GetTime::Rdtsc() - last_frame_tx_tsc_ > tsc_delta_) {
+    if ((GetTime::Rdtsc() - last_frame_tx_tsc) > tsc_delta_) {
       SendControlInformation();
-      last_frame_tx_tsc_ = GetTime::Rdtsc();
+      last_frame_tx_tsc = GetTime::Rdtsc();
     }
 
     // No need to process incomming packets if we are finished

--- a/src/mac/mac_thread_basestation.h
+++ b/src/mac/mac_thread_basestation.h
@@ -121,9 +121,6 @@ class MacThreadBaseStation {
   // The radio ID of the next MAC packet we'll hand over to the PHY
   size_t next_radio_id_ = 0;
 
-  // The timestamp at which we last scheduled a TTI (frame)
-  size_t last_frame_tx_tsc_ = 0;
-
   // The frame ID of the next TTI that the scheduler plans for
   size_t scheduler_next_frame_id_ = 0;
 

--- a/src/mac/mac_thread_client.h
+++ b/src/mac/mac_thread_client.h
@@ -126,9 +126,6 @@ class MacThreadClient {
   // The radio ID of the next MAC packet we'll hand over to the PHY
   size_t next_radio_id_ = 0;
 
-  // The timestamp at which we last scheduled a TTI (frame)
-  size_t last_frame_tx_tsc_ = 0;
-
   // The frame ID of the next TTI that the scheduler plans for
   size_t scheduler_next_frame_id_ = 0;
 

--- a/src/mac/video_receiver.cc
+++ b/src/mac/video_receiver.cc
@@ -9,22 +9,24 @@
 
 VideoReceiver::VideoReceiver(size_t port)
     : udp_video_receiver_(port, VideoReceiver::kVideoStreamSocketRxBufSize),
-      data_availble_(0),
-      data_start_offset_(0) { udp_video_receiver_.MakeBlocking(1); }
+      data_available_(0),
+      data_start_offset_(0) {
+  udp_video_receiver_.MakeBlocking(1);
+}
 
 void VideoReceiver::Load(char *destination, size_t num_load_bytes) {
-  if (num_load_bytes > data_availble_) {
+  if (num_load_bytes > data_available_) {
     //Check for potential local buffer wrap-around
-    if ((data_availble_ + data_start_offset_ +
+    if ((data_available_ + data_start_offset_ +
          VideoReceiver::kVideoStreamMaxRxSize) > local_rx_buffer_.size()) {
       memcpy(&local_rx_buffer_.at(0), &local_rx_buffer_.at(data_start_offset_),
-             data_availble_);
+             data_available_);
       data_start_offset_ = 0;
     }
 
-    while (data_availble_ < num_load_bytes) {
+    while (data_available_ < num_load_bytes) {
       ssize_t rcv_ret = udp_video_receiver_.Recv(
-          &local_rx_buffer_.at(data_start_offset_ + data_availble_),
+          &local_rx_buffer_.at(data_start_offset_ + data_available_),
           VideoReceiver::kVideoStreamMaxRxSize);
 
       if (rcv_ret < 0) {
@@ -34,17 +36,17 @@ void VideoReceiver::Load(char *destination, size_t num_load_bytes) {
         throw std::runtime_error(
             "[VideoReceiver] Received packet larger than max receive size -- "
             "inspect");
-      }
-      else if (rcv_ret > 0){
+      } else if (rcv_ret > 0) {
         std::printf("[VideoReceiver] data received: %zd\n", rcv_ret);
       }
-      data_availble_ += rcv_ret;
+      data_available_ += rcv_ret;
     }
   }
 
   //Copy data from local buffer to requested memory location
   memcpy(destination, &local_rx_buffer_.at(data_start_offset_), num_load_bytes);
-  std::printf("[VideoReceiver] Data loaded: %zu %zu %zu\n", num_load_bytes, data_availble_, data_start_offset_);
+  std::printf("[VideoReceiver] Data loaded: %zu %zu %zu\n", num_load_bytes,
+              data_available_, data_start_offset_);
   data_start_offset_ += num_load_bytes;
-  data_availble_ -= num_load_bytes;
+  data_available_ -= num_load_bytes;
 }

--- a/src/mac/video_receiver.cc
+++ b/src/mac/video_receiver.cc
@@ -1,0 +1,44 @@
+/**
+ * @file video_receiver.cc
+ * @brief Implementation file for the VideoReceiver class
+ */
+
+#include "video_receiver.h"
+
+VideoReceiver::VideoReceiver(size_t port)
+    : udp_video_receiver_(port, VideoReceiver::kVideoStreamSocketRxBufSize),
+      data_availble_(0),
+      data_start_offset_(0) {}
+
+void VideoReceiver::Load(char *destination, size_t num_load_bytes) {
+  if (num_load_bytes > data_availble_) {
+    //Check for potential local buffer wrap-around
+    if ((data_availble_ + data_start_offset_ +
+         VideoReceiver::kVideoStreamMaxRxSize) > local_rx_buffer_.size()) {
+      memcpy(&local_rx_buffer_.at(0), &local_rx_buffer_.at(data_start_offset_),
+             data_availble_);
+      data_start_offset_ = 0;
+    }
+
+    ssize_t rx_bytes = udp_video_receiver_.Recv(
+        &local_rx_buffer_.at(data_start_offset_ + data_availble_),
+        VideoReceiver::kVideoStreamMaxRxSize);
+
+    std::printf("[VideoReceiver] data received: %zd\n", rx_bytes);
+
+    if (rx_bytes < 0) {
+      throw std::runtime_error("[VideoReceiver] Receive error");
+    } else if (static_cast<size_t>(rx_bytes) >
+               VideoReceiver::kVideoStreamMaxRxSize) {
+      throw std::runtime_error(
+          "[VideoReceiver] Received packet larger than max receive size -- "
+          "inspect");
+    }
+    data_availble_ += rx_bytes;
+  }
+
+  //Copy data from local buffer to requested memory location
+  memcpy(destination, &local_rx_buffer_.at(data_start_offset_), num_load_bytes);
+  std::printf("[Receive Server] Data loaded: %zu\n", num_load_bytes);
+  data_start_offset_ += num_load_bytes;
+}

--- a/src/mac/video_receiver.cc
+++ b/src/mac/video_receiver.cc
@@ -10,7 +10,7 @@
 VideoReceiver::VideoReceiver(size_t port)
     : udp_video_receiver_(port, VideoReceiver::kVideoStreamSocketRxBufSize),
       data_availble_(0),
-      data_start_offset_(0) {}
+      data_start_offset_(0) { udp_video_receiver_.MakeBlocking(1); }
 
 void VideoReceiver::Load(char *destination, size_t num_load_bytes) {
   if (num_load_bytes > data_availble_) {
@@ -22,25 +22,29 @@ void VideoReceiver::Load(char *destination, size_t num_load_bytes) {
       data_start_offset_ = 0;
     }
 
-    ssize_t rx_bytes = udp_video_receiver_.Recv(
-        &local_rx_buffer_.at(data_start_offset_ + data_availble_),
-        VideoReceiver::kVideoStreamMaxRxSize);
+    while (data_availble_ < num_load_bytes) {
+      ssize_t rcv_ret = udp_video_receiver_.Recv(
+          &local_rx_buffer_.at(data_start_offset_ + data_availble_),
+          VideoReceiver::kVideoStreamMaxRxSize);
 
-    std::printf("[VideoReceiver] data received: %zd\n", rx_bytes);
-
-    if (rx_bytes < 0) {
-      throw std::runtime_error("[VideoReceiver] Receive error");
-    } else if (static_cast<size_t>(rx_bytes) >
-               VideoReceiver::kVideoStreamMaxRxSize) {
-      throw std::runtime_error(
-          "[VideoReceiver] Received packet larger than max receive size -- "
-          "inspect");
+      if (rcv_ret < 0) {
+        throw std::runtime_error("[VideoReceiver] Receive error");
+      } else if (static_cast<size_t>(rcv_ret) >
+                 VideoReceiver::kVideoStreamMaxRxSize) {
+        throw std::runtime_error(
+            "[VideoReceiver] Received packet larger than max receive size -- "
+            "inspect");
+      }
+      else if (rcv_ret > 0){
+        std::printf("[VideoReceiver] data received: %zd\n", rcv_ret);
+      }
+      data_availble_ += rcv_ret;
     }
-    data_availble_ += rx_bytes;
   }
 
   //Copy data from local buffer to requested memory location
   memcpy(destination, &local_rx_buffer_.at(data_start_offset_), num_load_bytes);
-  std::printf("[Receive Server] Data loaded: %zu\n", num_load_bytes);
+  std::printf("[VideoReceiver] Data loaded: %zu %zu %zu\n", num_load_bytes, data_availble_, data_start_offset_);
   data_start_offset_ += num_load_bytes;
+  data_availble_ -= num_load_bytes;
 }

--- a/src/mac/video_receiver.cc
+++ b/src/mac/video_receiver.cc
@@ -5,6 +5,8 @@
 
 #include "video_receiver.h"
 
+#include <cstring>
+
 VideoReceiver::VideoReceiver(size_t port)
     : udp_video_receiver_(port, VideoReceiver::kVideoStreamSocketRxBufSize),
       data_availble_(0),

--- a/src/mac/video_receiver.h
+++ b/src/mac/video_receiver.h
@@ -30,7 +30,7 @@ class VideoReceiver : public MacDataReceiver {
   VideoReceiver(size_t port);
   ~VideoReceiver() = default;
 
-  void Load(char *destination, size_t num_load_bytes) override final;
+  size_t Load(char *destination, size_t num_load_bytes) override final;
 
  private:
   UDPServer udp_video_receiver_;

--- a/src/mac/video_receiver.h
+++ b/src/mac/video_receiver.h
@@ -7,13 +7,14 @@
 
 #include <array>
 
+#include "mac_data_receiver.h"
 #include "udp_server.h"
 
 /**
  * @brief The Video Receiver class creates a UDP server to receive a video stream
  * tested with VLC streaming application
  */
-class VideoReceiver {
+class VideoReceiver : public MacDataReceiver {
  public:
   //Video stream specific variables
   static constexpr size_t kVideoStreamRxPort = 1350u;
@@ -29,7 +30,7 @@ class VideoReceiver {
   VideoReceiver(size_t port);
   ~VideoReceiver() = default;
 
-  void Load(char *destination, size_t num_load_bytes);
+  void Load(char *destination, size_t num_load_bytes) override final;
 
  private:
   UDPServer udp_video_receiver_;
@@ -40,4 +41,4 @@ class VideoReceiver {
   size_t data_start_offset_;
 };
 
-#endif  // MAC_THREAD_H_
+#endif  // VIDEO_RECEIVER_H_

--- a/src/mac/video_receiver.h
+++ b/src/mac/video_receiver.h
@@ -1,0 +1,43 @@
+/**
+ * @file video_receiver.h
+ * @brief Declaration file for the VideoReceiver class
+ */
+#ifndef VIDEO_RECEIVER_H_
+#define VIDEO_RECEIVER_H_
+
+#include <array>
+
+#include "udp_server.h"
+
+/**
+ * @brief The Video Receiver class creates a UDP server to receive a video stream
+ * tested with VLC streaming application
+ */
+class VideoReceiver {
+ public:
+  //Video stream specific variables
+  static constexpr size_t kVideoStreamRxPort = 1350u;
+  //Typical rx size for a UDP data packet comming from VLC udp streamer
+  static constexpr size_t kVideoStreamRxSize = (1316u);
+  static constexpr size_t kVideoStreamSocketRxBufSize =
+      (kVideoStreamRxSize * 1000u);
+  //Oversize the potential recieve size
+  static constexpr size_t kVideoStreamMaxRxSize = 2048u;
+  static constexpr size_t kVideoStreamLocalRxBufSize =
+      kVideoStreamMaxRxSize * 10;
+
+  VideoReceiver(size_t port);
+  ~VideoReceiver() = default;
+
+  void Load(char *destination, size_t num_load_bytes);
+
+ private:
+  UDPServer udp_video_receiver_;
+  std::array<uint8_t, VideoReceiver::kVideoStreamLocalRxBufSize>
+      local_rx_buffer_;
+
+  size_t data_availble_;
+  size_t data_start_offset_;
+};
+
+#endif  // MAC_THREAD_H_

--- a/src/mac/video_receiver.h
+++ b/src/mac/video_receiver.h
@@ -18,11 +18,11 @@ class VideoReceiver : public MacDataReceiver {
  public:
   //Video stream specific variables
   static constexpr size_t kVideoStreamRxPort = 1350u;
-  //Typical rx size for a UDP data packet comming from VLC udp streamer
+  //Typical rx size for a UDP data packet coming from VLC udp streamer
   static constexpr size_t kVideoStreamRxSize = (1316u);
   static constexpr size_t kVideoStreamSocketRxBufSize =
       (kVideoStreamRxSize * 1000u);
-  //Oversize the potential recieve size
+  //Oversize the potential receive size
   static constexpr size_t kVideoStreamMaxRxSize = 2048u;
   static constexpr size_t kVideoStreamLocalRxBufSize =
       kVideoStreamMaxRxSize * 10;
@@ -37,7 +37,7 @@ class VideoReceiver : public MacDataReceiver {
   std::array<uint8_t, VideoReceiver::kVideoStreamLocalRxBufSize>
       local_rx_buffer_;
 
-  size_t data_availble_;
+  size_t data_available_;
   size_t data_start_offset_;
 };
 


### PR DESCRIPTION
Fixes issue with the MacThreads (Bs and User) where a non-blocking call to udp receive cannot complete the entire frame without polling the rx call.  Also abstracts the mac file reader class interface to replace with a UDP source.  The UDP data source still needs tested more but the files are currently inactive.   That feature will be added to the readme once verified. 